### PR TITLE
add unit test example with changed property

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Get around the lack of a `.hover()` command.
 - Test simple math functions.
 - Test the canonical *fizzbuzz* test.
 - Automatically retry assertion until a given property inside an object:
-  * is added or delted
+  * is added or deleted
   * has expected value
 
 ### [React with Enzyme](./examples/unit-testing__react-enzyme)

--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ Get around the lack of a `.hover()` command.
 - Import modules using ES2015.
 - Test simple math functions.
 - Test the canonical *fizzbuzz* test.
+- Automatically retry assertion until a given property inside an object:
+  * is added or delted
+  * has expected value
 
 ### [React with Enzyme](./examples/unit-testing__react-enzyme)
 

--- a/examples/blogs__direct-control-angular/cypress/integration/spec.js
+++ b/examples/blogs__direct-control-angular/cypress/integration/spec.js
@@ -1,14 +1,14 @@
 const getAngular = () => cy.window().its('angular')
 
-const getElementScope = selector =>
-  cy.get(selector).then($el => getAngular().then(ng => ng.element($el).scope()))
+const getElementScope = (selector) =>
+  cy.get(selector).then(($el) => getAngular().then((ng) => ng.element($el).scope()))
 
-const getElementInjector = selector =>
+const getElementInjector = (selector) =>
   cy
-    .get(selector)
-    .then($el => getAngular().then(ng => ng.element($el).injector()))
+  .get(selector)
+  .then(($el) => getAngular().then((ng) => ng.element($el).injector()))
 
-const addTodo = text => cy.get('#new-todo').type(text).type('{enter}')
+const addTodo = (text) => cy.get('.new-todo').type(text).type('{enter}')
 
 describe('Angular TodoMVC', () => {
   beforeEach(() => {
@@ -20,35 +20,35 @@ describe('Angular TodoMVC', () => {
   })
 
   it('adds a todo', () => {
-    cy.get('#new-todo').type('new todo').type('{enter}')
+    cy.get('.new-todo').type('new todo').type('{enter}')
 
     cy
-      .get('#todo-list')
-      .find('li')
-      .should('have.length', 1)
-      .first()
-      .contains('new todo')
+    .get('.todo-list')
+    .find('li')
+    .should('have.length', 1)
+    .first()
+    .contains('new todo')
   })
 
   it('can get angular library', () => {
     cy
-      .window()
-      .then(win => {
-        console.log('got app window object', win)
-        return win
-      })
-      .its('angular')
-      .then(ng => {
-        console.log('got angular object', ng.version)
-      })
+    .window()
+    .then((win) => {
+      console.log('got app window object', win)
+      return win
+    })
+    .its('angular')
+    .then((ng) => {
+      console.log('got angular object', ng.version)
+    })
   })
 
   it('has todo object in scope', () => {
-    cy.get('#new-todo').type('new todo').type('{enter}')
+    cy.get('.new-todo').type('new todo').type('{enter}')
 
-    getElementScope('#todo-list li:first').its('todo').should('deep.equal', {
+    getElementScope('.todo-list li:first').its('todo').should('deep.equal', {
       title: 'new todo',
-      completed: false
+      completed: false,
     })
   })
 
@@ -56,9 +56,9 @@ describe('Angular TodoMVC', () => {
     const title = 'learn E2E testing with Cypress'
     addTodo(title)
 
-    getElementScope('#todo-list li:first').its('todo').should('deep.equal', {
+    getElementScope('.todo-list li:first').its('todo').should('deep.equal', {
       title,
-      completed: false
+      completed: false,
     })
   })
 
@@ -66,80 +66,80 @@ describe('Angular TodoMVC', () => {
     const title = 'learn E2E testing with Cypress'
     addTodo(title)
 
-    getElementScope('#todo-list li:first').its('todo').then(todo => {
+    getElementScope('.todo-list li:first').its('todo').then((todo) => {
       todo.completed = true
     })
 
-    getElementScope('#todo-list li:first').then(scope => {
+    getElementScope('.todo-list li:first').then((scope) => {
       // must run digest cycle so Angular
       // updates DOM
       scope.$apply()
     })
 
     // check UI - it should have been updated
-    cy.get('#todo-list li:first').find('input.toggle').should('be.checked')
+    cy.get('.todo-list li:first').find('input.toggle').should('be.checked')
   })
 
   it('set several todos at once', () => {
     // home app handles missing "completed" property
     const todos = [
       {
-        title: 'first todo'
+        title: 'first todo',
       },
       {
-        title: 'second todo'
+        title: 'second todo',
       },
       {
-        title: 'third todo'
-      }
+        title: 'third todo',
+      },
     ]
 
-    getElementScope('#todo-list').then(scope => {
+    getElementScope('.todo-list').then((scope) => {
       scope.todos = todos
       scope.$apply()
     })
 
     // we should have 3 elements in the list
-    cy.get('#todo-list li').should('have.length', 3)
+    cy.get('.todo-list li').should('have.length', 3)
   })
 
   it('shows completed items', () => {
     // home app handles missing "completed" property
     const todos = [
       {
-        title: 'first todo'
+        title: 'first todo',
       },
       {
         title: 'second todo',
-        completed: true
+        completed: true,
       },
       {
-        title: 'third todo'
-      }
+        title: 'third todo',
+      },
     ]
 
-    getElementScope('#todo-list').then(scope => {
+    getElementScope('.todo-list').then((scope) => {
       scope.todos = todos
       scope.$apply()
     })
 
-    getElementInjector('#todo-list').then(injector => {
+    getElementInjector('.todo-list').then((injector) => {
       const store = injector.get('localStorage')
-      todos.forEach(t => store.insert(t))
+      todos.forEach((t) => store.insert(t))
     })
 
-    cy.get('#filters').contains('Completed').click()
+    cy.get('.filters').contains('Completed').click()
 
-    cy.get('#todo-list li').should('have.length', 1)
+    cy.get('.todo-list li').should('have.length', 1)
   })
 
   it('sets todo using addTodo scope method', () => {
-    getElementScope('#todo-list').then(scope => {
+    getElementScope('.todo-list').then((scope) => {
       scope.newTodo = 'this is a todo'
       scope.addTodo()
       scope.$apply()
     })
 
-    cy.get('#todo-list li').should('have.length', 1)
+    cy.get('.todo-list li').should('have.length', 1)
   })
 })

--- a/examples/unit-testing__application-code/cypress/integration/unit_test_application_code_spec.js
+++ b/examples/unit-testing__application-code/cypress/integration/unit_test_application_code_spec.js
@@ -1,7 +1,123 @@
-import { add, subtract, divide, multiply } from '../../math'
-import fizzbuzz from '../../fizzbuzz'
+import fizzbuzz from '../../fizzbuzz';
+import { add, divide, multiply, subtract } from '../../math';
 
 describe('Unit Test Application Code', function(){
+
+  // several unit tests showing how Cypress wraps an object
+  // and can wait for a property to:
+  //  - change its value
+  //  - be added to the object
+  //  - be deleted from the object
+  context('waiting for a property of an object', () => {
+    it('detects an existing property', () => {
+      // assert given object has a property with a given value
+      expect({foo: 42}).to.have.property('foo', 42)
+
+      // alternative - use cy.wrap + "should" syntax
+      // @see https://on.cypress.io/wrap
+      cy.wrap({foo: 42}).should('have.property', 'foo', 42)
+    })
+
+    it('waits for changed property value', () => {
+      const o = {foo: 20}
+
+      // changes property "foo" after delay
+      setTimeout(() => {
+        o.foo = 42
+      }, 100)
+
+      // "expect" syntax does NOT work
+      // because it is not retried!
+      // expect(o).to.have.property('foo', 42)
+
+      // wrapping an object and using "should" syntax retries
+      // the assertion until the "o.foo = 42" runs and the assertion passes
+      cy.wrap(o).should('have.property', 'foo', 42)
+    })
+
+    it('waits for added property value', () => {
+      const o = {}
+      setTimeout(() => {
+        o.foo = 42
+      }, 100)
+
+      // wrapping an object and using "should" syntax retries
+      // the assertion until the "o.foo = 42" runs and the assertion passes
+      cy.wrap(o).should('have.property', 'foo', 42)
+
+      // if we are not interested the value we could use assertion
+      //  .should('have.property', 'foo')
+    })
+
+    it('waits for added property using .its', () => {
+      const o = {}
+      setTimeout(() => {
+        o.foo = 42
+      }, 100)
+
+      // @see https://on.cypress.io/its
+      cy.wrap(o).its('foo').should('exist')
+    })
+
+    it('waits for property to be deleted', () => {
+      const o = {
+        foo: 42
+      }
+      setTimeout(() => {
+        delete o.foo
+      }, 100)
+
+      // @see https://on.cypress.io/its
+      // we cannot use cy.wrap(o).its('foo').should...
+      // because the property exists from the start and becomes
+      // the subject of the command chain right away
+      // so we must wrap the object and use assertion on the object
+      cy.wrap(o).should('not.have.property', 'foo')
+    })
+
+    it('waits for added property value using .its', () => {
+      const o = {}
+      setTimeout(() => {
+        o.foo = 42
+      }, 100)
+
+      // @see https://on.cypress.io/its
+      cy.wrap(o).its('foo').should('eq', 42)
+    })
+
+    it('waits for added nested property value', () => {
+      const o = {}
+      setTimeout(() => {
+        o.foo = {
+          bar: {
+            baz: 42
+          }
+        }
+      }, 100)
+
+      // cy.its is awesome for waiting for a nested property that
+      // passes assertion after it
+      cy.wrap(o).its('foo.bar.baz').should('equal', 42)
+    })
+
+    it('waits for deleted nested property', () => {
+      const o = {
+        foo: {
+          bar: {
+            baz: 42
+          }
+        }
+      }
+      setTimeout(() => {
+        delete o.foo.bar.baz
+      }, 100)
+
+      // traverse the object to {baz: 42} and retry assertion
+      // until the subject {baz: 42} does NOT have property "baz"
+      cy.wrap(o).its('foo.bar').should('not.have.property', 'baz')
+    })
+  })
+
   context('math.js', function(){
     it('can add numbers', function(){
       expect(add(1, 2)).to.eq(3)

--- a/examples/unit-testing__application-code/cypress/integration/unit_test_application_code_spec.js
+++ b/examples/unit-testing__application-code/cypress/integration/unit_test_application_code_spec.js
@@ -116,6 +116,14 @@ describe('Unit Test Application Code', function(){
       // until the subject {baz: 42} does NOT have property "baz"
       cy.wrap(o).its('foo.bar').should('not.have.property', 'baz')
     })
+
+    it('waits for a variable to be set on application\'s Window object', () => {
+      cy.visit('./index.html')
+      // similar to above examples, cy.window() yields application's Window
+      // object and we tell Cypress to retry until that object has property "AppReady"
+      // and its value is `true`.
+      cy.window().should('have.property', 'AppReady', true)
+    })
   })
 
   context('math.js', function(){

--- a/examples/unit-testing__application-code/cypress/integration/unit_test_application_code_spec.js
+++ b/examples/unit-testing__application-code/cypress/integration/unit_test_application_code_spec.js
@@ -45,7 +45,7 @@ describe('Unit Test Application Code', function(){
       // the assertion until the "o.foo = 42" runs and the assertion passes
       cy.wrap(o).should('have.property', 'foo', 42)
 
-      // if we are not interested the value we could use assertion
+      // if we are not interested in the value we could use assertion
       //  .should('have.property', 'foo')
     })
 

--- a/examples/unit-testing__application-code/index.html
+++ b/examples/unit-testing__application-code/index.html
@@ -1,0 +1,7 @@
+<body>
+  <script>
+    setTimeout(() => {
+      window.AppReady = true
+    }, 100)
+  </script>
+</body>


### PR DESCRIPTION
Sometimes a user wants to wait for some flag variable, like something added to `window` object or some global variable set. I have written a few unit tests that show how to detect an added property, deleted, deeply nested property, changed property value.