### PR TITLE
split long recipes table to individual tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Recipes [![CircleCI](https://circleci.com/gh/cypress-io/cypress-example-recipes/tree/master.svg?style=svg)](https://circleci.com/gh/cypress-io/cypress-example-recipes/tree/master) [![Travis CI](https://travis-ci.org/cypress-io/cypress-example-recipes.svg?branch=master)](https://travis-ci.org/cypress-io/cypress-example-recipes) [![renovate-app badge][renovate-badge]][renovate-app]
 
-> This repo contains various recipes for testing common scenarios using Cypress.
+> This repo contains various recipes for testing common scenarios using Cypress: [Fundamentals](#fundamentals), [Testing the DOM](#testing-the-dom), [Logging in](#logging-in-recipes), [Preprocessors](#preprocessors), [Blogs](#blogs), [Stubbing and spying](#stubbing-and-spying), [Unit Testing](#unit-testing), [Server Communication](#server-communication)
+
+## Fundamentals
+
+Recipe | Description
+--- | ---
+[Node Modules](#node-modules) | Import your own node modules
+[Environment variables](#environment-variables) | Passing environment variables to tests
+[Dynamic tests](#dynamic-tests) | Create tests dynamically from data
+[Fixtures](#fixtures) | Loading single or multiple fixtures
+[Adding Chai Assertions](#adding-chai-assertions) | Add new or custom chai assertions
+
+## Testing the DOM
+
+Recipe | Description
+--- | ---
+[Tab Handling and Links](#tab-handling-and-links) | Links that open in a new tab
+[Hover and Hidden Elements](#hover-and-hidden-elements) | Test hidden elements requiring hover
+[Form Interactions](#form-interactions) | Test form elements like input type `range`
+[Drag and Drop](#drag-and-drop) | Use `.trigger()` to test drag and drop
 
 ## Logging in recipes
 
@@ -13,39 +32,52 @@ Recipe | Description
 
 Also see [Authentication plugins](https://on.cypress.io/plugins#authentication) and watch video ["Organizing Tests, Logging In, Controlling State"](https://www.youtube.com/watch?v=5XQOK0v_YRE)
 
-## Other recipes
+## Preprocessors
 
-Recipe | Category | Description
---- | --- | ---
-[Node Modules](#node-modules) | Fundamentals | Import your own node modules
-[Environment variables](#environment-variables) | Fundamentals | Passing environment variables to tests
-[Dynamic tests](#dynamic-tests) | Fundamentals | Create tests dynamically from data
-[Fixtures](#fixtures) | Fundamentals | Loading single or multiple fixtures
-[Tab Handling and Links](#tab-handling-and-links) | Testing the DOM | Links that open in a new tab
-[Hover and Hidden Elements](#hover-and-hidden-elements) | Testing the DOM | Test hidden elements requiring hover
-[Form Interactions](#form-interactions) | Testing the DOM | Test form elements like input type `range`
-[Drag and Drop](#drag-and-drop) | Testing the DOM | Use `.trigger()` to test drag and drop
-[grep](#grep) | Preprocessors | Filter tests by name using Mocha-like `grep` syntax
-[Typescript with Browserify](#typescript-with-browserify) | Preprocessors | Add typescript support with browserify
-[Typescript with Webpack](#typescript-with-webpack) | Preprocessors | Add typescript support with webpack
-[Application Actions](#application-actions) | Blogs | Application actions are a replacement for Page Objects
-[Direct Control of AngularJS](#direct-control-of-angularjs) | Blogs | Bypass the DOM and control AngularJS
-[E2E API Testing](#e2e-api-testing) | Blogs | Run your API Tests with a GUI
-[E2E Snapshots](#e2e-snapshots) | Blogs | End-to-End Snapshot Testing
-[Element Coverage](#element-coverage) | Blogs | Track elements covered by tests
-[Codepen.io Testing](#codepen-testing) | Blogs | Test a HyperApp Codepen demo
-[Testing Redux Store](#testing-redux-store) | Blogs | Test an application that uses Redux data store
-[Vue + Vuex + REST Testing](#vue--vuex--rest-testing) | Blogs | Test an application that uses central data store
-[Stubbing Functions](#stubbing-functions) | Stubbing, Spying | Use `cy.stub()` to test function calls
-[Stubbing `window.fetch`](#stubbing-windowfetch) | Stubbing, Spying | Use `cy.stub()` to control fetch requests
-[Stubbing methods called on `window`](#stubbing-methods-called-on-window) | Stubbing, Spying | Use `cy.stub()` for methods called on `window`
-[Stubbing Google Analytics](#stubbing-google-analytics) | Stubbing, Spying | Use `cy.stub()` to test Google Analytics calls
-[Application Code](#application-code) | Unit Testing | Import and test your own application code
-[React](#react) | Unit Testing | Test your React components in isolation
-[File Upload in React](#file-upload-in-react) | Unit Testing | Test file upload in React app
-[Adding Chai Assertions](#adding-chai-assertions) | Extending Cypress | Add new or custom chai assertions
-[Bootstrapping your App](#bootstrapping-your-app) | Server Communication | Seed your application with test data
-[Seeding your Database in Node](#seeding-your-database-in-node) | Server Communication | Seed your database with test data
+Recipe | Description
+--- | ---
+[grep](#grep) | Filter tests by name using Mocha-like `grep` syntax
+[Typescript with Browserify](#typescript-with-browserify) | Add typescript support with browserify
+[Typescript with Webpack](#typescript-with-webpack) | Add typescript support with webpack
+
+## Blogs
+
+Demo recipes from the blog posts at [www.cypress.io/blog](https://www.cypress.io/blog)
+
+Recipe | Description
+--- | ---
+[Application Actions](#application-actions) | Application actions are a replacement for Page Objects
+[Direct Control of AngularJS](#direct-control-of-angularjs) | Bypass the DOM and control AngularJS
+[E2E API Testing](#e2e-api-testing) | Run your API Tests with a GUI
+[E2E Snapshots](#e2e-snapshots) | End-to-End Snapshot Testing
+[Element Coverage](#element-coverage) | Track elements covered by tests
+[Codepen.io Testing](#codepen-testing) | Test a HyperApp Codepen demo
+[Testing Redux Store](#testing-redux-store) | Test an application that uses Redux data store
+[Vue + Vuex + REST Testing](#vue--vuex--rest-testing) | Test an application that uses central data store
+
+## Stubbing and spying
+
+Recipe | Description
+--- | ---
+[Stubbing Functions](#stubbing-functions) | Use `cy.stub()` to test function calls
+[Stubbing `window.fetch`](#stubbing-windowfetch) | Use `cy.stub()` to control fetch requests
+[Stubbing methods called on `window`](#stubbing-methods-called-on-window) | Use `cy.stub()` for methods called on `window`
+[Stubbing Google Analytics](#stubbing-google-analytics) | Use `cy.stub()` to test Google Analytics calls
+
+## Unit Testing
+
+Recipe | Description
+--- | ---
+[Application Code](#application-code) | Import and test your own application code
+[React](#react) | Test your React components in isolation
+[File Upload in React](#file-upload-in-react) | Test file upload in React app
+
+## Server Communication
+
+Recipe | Description
+--- | ---
+[Bootstrapping your App](#bootstrapping-your-app) | Seed your application with test data
+[Seeding your Database in Node](#seeding-your-database-in-node) | Seed your database with test data
 
 ## Overview
 


### PR DESCRIPTION
- each group can be addressed separately
- a convenient way to jump from the top

<img width="996" alt="Screen Shot 2019-03-26 at 3 30 29 PM" src="https://user-images.githubusercontent.com/2212006/55027637-1ed22a00-4fdc-11e9-8c8c-dc4c8dfca111.png">
