### PR TITLE
Update stubbing fetch recipe

### DIFF
--- a/examples/stubbing-spying__window-fetch/README.md
+++ b/examples/stubbing-spying__window-fetch/README.md
@@ -13,6 +13,12 @@ Spec | Description
 
 ## Stubbing `fetch`
 
-Cypress wraps the native XMLHttpRequest object to allow observing and stubbing network requests from the application. It also polyfills the native `window.fetch` method to work via wrapped XMLHttpRequest - this is how we allow network stubbing for applications that use `fetch` calls.
+Cypress wraps the native XMLHttpRequest object to allow observing and stubbing network requests from the application. It also polyfills the native `window.fetch` method to work via wrapped XMLHttpRequest - this is how we allow network stubbing for applications that use `fetch` calls. See [cypress.json](cypress.json)
+
+```json
+{
+  "experimentalFetchPolyfill": true
+}
+```
 
 In the future we plan to move network stubbing into Cypress' proxy layer, allowing much more powerful and complete network control. Watch issue [#95][issue] for progress.

--- a/examples/stubbing-spying__window-fetch/cypress/integration/stub-fetch-spec.js
+++ b/examples/stubbing-spying__window-fetch/cypress/integration/stub-fetch-spec.js
@@ -2,10 +2,34 @@
 // @ts-check
 
 describe('stubbing', function () {
+  it('directly stubs window.fetch to test loading indicator', () => {
+    // stub the "fetch(/favorite-fruits)" call from the app
+    cy.visit('/', {
+      onBeforeLoad (win) {
+        cy.stub(win, 'fetch').withArgs('/favorite-fruits')
+        .resolves(
+          // use Bluebird promise bundled with Cypress
+          // to resolve after 2000ms
+          Cypress.Promise.resolve({
+            ok: true,
+            json: () => ['Pineapple 🍍'],
+          }).delay(2000)
+        )
+      },
+    })
+
+    // at first, the app is showing the loading indicator
+    cy.get('.loader').should('be.visible')
+    // once the promise is resolved, the loading indicator goes away
+    cy.get('.loader').should('not.exist')
+    cy.contains('li', 'Pineapple 🍍')
+  })
+
   // A big advantage of controlling the response is we can test
   // how our app handles a slow response, which normally might be
   // difficult against a fast development server
   it('shows loader while fetching fruits', function () {
+    // stub the XHR request from the app
     cy.server()
     cy.route({
       url: '/favorite-fruits',

--- a/examples/stubbing-spying__window-fetch/cypress/integration/stub-fetch-spec.js
+++ b/examples/stubbing-spying__window-fetch/cypress/integration/stub-fetch-spec.js
@@ -1,4 +1,5 @@
 /// <reference types="Cypress" />
+// @ts-check
 
 describe('stubbing', function () {
   // A big advantage of controlling the response is we can test
@@ -8,7 +9,7 @@ describe('stubbing', function () {
     cy.server()
     cy.route({
       url: '/favorite-fruits',
-      reponse: [],
+      response: [],
       delay: 1000,
     })
 
@@ -17,6 +18,7 @@ describe('stubbing', function () {
 
     // once the network call finishes, the loader goes away
     cy.get('.loader').should('not.exist')
+    cy.contains('.favorite-fruits', 'No favorites')
   })
 
   it('can spy on network calls from the second page', () => {

--- a/examples/stubbing-spying__window-fetch/package.json
+++ b/examples/stubbing-spying__window-fetch/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",
+    "dev": "../../node_modules/.bin/start-test 7080 cypress:open",
     "start": "node server.js --port 7080",
     "test:ci": "../../node_modules/.bin/start-test 7080 cypress:run"
   }


### PR DESCRIPTION
- fix typo in the response
- add example stubbing `window.fetch` directly with delayed resolved value
This is for a new blog post I want to quickly write for v4.9.0 and experimental fetch polyfill