### PR TITLE
update ajax examples with Select2

### DIFF
--- a/examples/testing-dom__select2/README.md
+++ b/examples/testing-dom__select2/README.md
@@ -1,7 +1,7 @@
 # testing-dom__select2
 > Testing select elements and Select2 widgets
 
-This example shows how end-to-end tests work with plain `<select>` HTML elements and with  [Select2](https://select2.org/) widgets.
+This example shows how end-to-end tests work with plain `<select>` HTML elements and with  [Select2](https://select2.org/) widgets. Read the blog post [Working with Select elements and Select2 widgets in Cypress](https://www.cypress.io/blog/2020/03/20/working-with-select-elements-and-select2-widgets-in-cypress/)
 
 Find all tests in the [cypress/integration/spec.js](cypress/integration/spec.js) file
 
@@ -10,5 +10,6 @@ Find all tests in the [cypress/integration/spec.js](cypress/integration/spec.js)
 - selecting a single value using `Select2`
 - selecting multiple values using `Select2`
 - removing one of the selected values using `Select2`
+- selecting a value from the list dynamically populated from Ajax call using `Select2`
 
 ![demo](images/demo.gif)

--- a/examples/testing-dom__select2/cypress/integration/spec.js
+++ b/examples/testing-dom__select2/cypress/integration/spec.js
@@ -244,6 +244,32 @@ describe('select2', () => {
         cy.get('#select2-user-container').should('have.text', user.name)
       })
     })
+
+    it('selects the user from stubbed Ajax call', () => {
+      cy.server()
+      // do not go to the server, mock the response instead
+      // but return the response after a delay
+      cy.route({
+        url: 'https://jsonplaceholder.cypress.io/users?_type=query',
+        response: [{
+          id: 101,
+          name: 'Joe Smith',
+        }, {
+          id: 201,
+          name: 'Mary Jane',
+        }],
+        delay: 2000,
+      })
+
+      cy.get('#select2-user-container').click()
+
+      // keep retrying finding the element until it is present
+      cy.contains('.select2-results__option', 'Mary Jane', { timeout: 2500 }).click()
+
+      // confirm the user was selected
+      cy.get('#user').should('have.value', 201)
+      cy.get('#select2-user-container').should('have.text', 'Mary Jane')
+    })
   })
 
   context('programmatic control', () => {

--- a/examples/testing-dom__select2/cypress/integration/spec.js
+++ b/examples/testing-dom__select2/cypress/integration/spec.js
@@ -158,6 +158,38 @@ describe('select2', () => {
   context('ajax data source', () => {
     // Select2 Ajax data fetch docs at https://select2.org/data-sources/ajax
 
+    // NOTE: test shows what will NOT work
+    it.skip('selects a value - WILL NOT WORK, JUST A DEMO', () => {
+      // clicking on the container starts Ajax call
+      cy.get('#select2-user-container').click()
+
+      // we know the choice elements have this class
+      cy.get('.select2-results__option')
+      // so let's try finding the element with the text
+      // WILL NOT WORK because our search is limited
+      // to the initial empty set of results
+      // from the previous ".get" command
+      .contains('Leanne Graham').click()
+
+      // confirm the right user is found
+      cy.get('#user').should('have.value', '1')
+      cy.get('#select2-user-container').should('have.text', 'Leanne Graham')
+    })
+
+    it('selects a value by waiting for loading class to go away', () => {
+      // clicking on the container starts Ajax call
+      cy.get('#select2-user-container').click()
+
+      cy.get('.select2-results__option')
+      .should('not.have.class', 'loading-results')
+      // great, now the results are shown in the DOM
+      .contains('Leanne Graham').click()
+
+      // confirm the right user is found
+      cy.get('#user').should('have.value', '1')
+      cy.get('#select2-user-container').should('have.text', 'Leanne Graham')
+    })
+
     it('selects a value by retrying', () => {
       // clicking on the container starts Ajax call
       cy.get('#select2-user-container').click()


### PR DESCRIPTION
- retry logic
- ajax wait + DOM retry
- using response to select an item
- checking class goes away
- [x] update the blog post https://www.cypress.io/blog/2020/03/20/working-with-select-elements-and-select2-widgets-in-cypress/ by adding a new section for ajax

cc @randomsync 