### PR TITLE
record AppVeyor runs on dashboard

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "10"
+  nodejs_version: "12"
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -33,7 +33,7 @@ cache:
   # using APPVEYOR_SAVE_CACHE_ON_ERROR: true environment variable
 
 test_script:
-  - npm run test:ci:windows
+  - npm run test:ci:windows -- --record
 
 # Don't actually build, we are only interested in tests
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ cache:
   # using APPVEYOR_SAVE_CACHE_ON_ERROR: true environment variable
 
 test_script:
-  - npm run test:ci:windows -- --record
+  - npm run test:ci:windows:record
 
 # Don't actually build, we are only interested in tests
 build: off

--- a/examples/blogs__application-actions/cypress.json
+++ b/examples/blogs__application-actions/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:8888",
   "ignoreTestFiles": "utils.js",
-  "fixturesFolder": false
+  "fixturesFolder": false,
+  "defaultCommandTimeout": 8000
 }

--- a/examples/blogs__application-actions/package.json
+++ b/examples/blogs__application-actions/package.json
@@ -9,12 +9,14 @@
     "cypress:run:chrome": "../../node_modules/.bin/cypress run --browser chrome",
     "cypress:run:firefox": "../../node_modules/.bin/cypress run --browser firefox",
     "cypress:run:win": "bin-up cypress run",
+    "cypress:run:win:record": "bin-up cypress run --record",
     "dev": "../../node_modules/.bin/start-test 8888 cypress:open",
     "start": "../../node_modules/.bin/http-server -p 8888 --silent -c-1",
     "start:win": "bin-up serve -l 8888 --no-clipboard",
     "test:ci": "../../node_modules/.bin/start-test 8888 cypress:run",
     "test:ci:chrome": "../../node_modules/.bin/start-test 8888 cypress:run:chrome",
     "test:ci:firefox": "../../node_modules/.bin/start-test 8888 cypress:run:firefox",
-    "test:ci:windows": "bin-up start-test start:win http://localhost:8888 cypress:run:win"
+    "test:ci:windows": "bin-up start-test start:win http://localhost:8888 cypress:run:win",
+    "test:ci:windows:record": "bin-up start-test start:win http://localhost:8888 cypress:run:win:record"
   }
 }

--- a/examples/blogs__application-actions/package.json
+++ b/examples/blogs__application-actions/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blogs__page-actions",
+  "name": "blogs__application-actions",
   "version": "1.0.0",
   "description": "Testing Redux store using Cypress",
   "private": true,
@@ -9,7 +9,7 @@
     "cypress:run:chrome": "../../node_modules/.bin/cypress run --browser chrome",
     "cypress:run:firefox": "../../node_modules/.bin/cypress run --browser firefox",
     "cypress:run:win": "bin-up cypress run",
-    "cypress:run:win:record": "bin-up cypress run --record",
+    "cypress:run:win:record": "bin-up cypress run --record --group blogs__application-actions",
     "dev": "../../node_modules/.bin/start-test 8888 cypress:open",
     "start": "../../node_modules/.bin/http-server -p 8888 --silent -c-1",
     "start:win": "bin-up serve -l 8888 --no-clipboard",

--- a/examples/blogs__e2e-api-testing/package.json
+++ b/examples/blogs__e2e-api-testing/package.json
@@ -1,14 +1,16 @@
 {
-  "name": "cypress-example-api-testing",
+  "name": "blogs__e2e-api-testing",
   "version": "1.0.0",
   "description": "Cypress E2E runner can also test Rest and other APIs",
   "scripts": {
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",
     "cypress:run:windows": "bin-up cypress run",
+    "cypress:run:windows:record": "bin-up cypress run --record --group blogs__e2e-api-testing",
     "start": "../../node_modules/.bin/json-server db.json --port 7081 --quiet",
     "start:windows": "bin-up json-server db.json --port 7081 --quiet",
     "test:ci": "../../node_modules/.bin/start-test 7081 cypress:run",
-    "test:ci:windows": "bin-up start-test start:windows 7081 cypress:run:windows"
+    "test:ci:windows": "bin-up start-test start:windows 7081 cypress:run:windows",
+    "test:ci:windows:record": "bin-up start-test start:windows 7081 cypress:run:windows:record"
   }
 }

--- a/examples/file-upload-react/package.json
+++ b/examples/file-upload-react/package.json
@@ -7,6 +7,7 @@
     "cypress:run": "../../node_modules/.bin/cypress run",
     "start": "echo nothing to start, this recipe does not run server",
     "test:ci": "../../node_modules/.bin/cypress run",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group file-upload-react"
   }
 }

--- a/examples/fundamentals__dynamic-tests/package.json
+++ b/examples/fundamentals__dynamic-tests/package.json
@@ -6,6 +6,7 @@
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",
     "test:ci": "npm run cypress:run",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group dynamic-tests"
   }
 }

--- a/examples/fundamentals__fixtures/package.json
+++ b/examples/fundamentals__fixtures/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "dynamic-tests",
+  "name": "fundamentals__fixtures",
   "version": "1.0.0",
   "description": "Create Cypress tests dynamically from data",
   "scripts": {
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",
     "test:ci": "../../node_modules/.bin/cypress run",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group fundamentals__fixtures"
   }
 }

--- a/examples/fundamentals__node-modules/package.json
+++ b/examples/fundamentals__node-modules/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "es2015-commonsjs-modules",
+  "name": "fundamentals__node_modules",
   "version": "1.0.0",
   "description": "Use NPM modules from Cypress specs",
   "scripts": {
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",
     "test:ci": "../../node_modules/.bin/cypress run",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group fundamentals__node_modules"
   }
 }

--- a/examples/testing-dom__lit-element/package.json
+++ b/examples/testing-dom__lit-element/package.json
@@ -8,6 +8,7 @@
     "start": "echo there is no web server to start in this project",
     "test:ci": "npm run cypress:run",
     "test:ci:firefox": "npm run cypress:run -- --browser firefox",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group unit-test-lit-element"
   }
 }

--- a/examples/unit-testing__application-code/package.json
+++ b/examples/unit-testing__application-code/package.json
@@ -8,6 +8,7 @@
     "start": "echo there is no web server to start in this project",
     "test:ci": "npm run cypress:run",
     "test:ci:firefox": "npm run cypress:run -- --browser firefox",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group unit-test-application-code"
   }
 }

--- a/examples/unit-testing__react-apollo/package.json
+++ b/examples/unit-testing__react-apollo/package.json
@@ -8,6 +8,7 @@
     "start": "echo nothing to start, unit testing example",
     "test:ci": "npm run cypress:run",
     "test:ci:firefox": "npm run cypress:run -- --browser firefox",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group unit-testing__react-apollo"
   }
 }

--- a/examples/unit-testing__react-skeleton/package.json
+++ b/examples/unit-testing__react-skeleton/package.json
@@ -8,6 +8,7 @@
     "start": "echo nothing to start, unit testing example",
     "test:ci": "npm run cypress:run",
     "test:ci:firefox": "npm run cypress:run -- --browser firefox",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group unit-testing__react-skeleton"
   }
 }

--- a/examples/unit-testing__react/package.json
+++ b/examples/unit-testing__react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unit-test-react-enzyme",
+  "name": "unit-testing__react",
   "version": "1.0.0",
   "description": "Unit testing React code using Enzyme, react-testing-library and cypress-react-unit-test",
   "scripts": {
@@ -8,6 +8,7 @@
     "start": "echo nothing to start, unit testing example",
     "test:ci": "npm run cypress:run",
     "test:ci:firefox": "npm run cypress:run -- --browser firefox",
-    "test:ci:windows": "bin-up cypress run"
+    "test:ci:windows": "bin-up cypress run",
+    "test:ci:windows:record": "bin-up cypress run --record --group unit-testing__react"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ci:chrome:headless": "node ./test-examples --chrome --headless",
     "test:ci:firefox": "node ./test-examples --firefox",
     "test:ci:windows": "node ./test-examples --windows",
+    "test:ci:windows:record": "node ./test-examples --windows --record",
     "warn-only": "stop-only --warn --folder examples --skip node_modules"
   },
   "husky": {

--- a/test-examples.js
+++ b/test-examples.js
@@ -58,6 +58,11 @@ if (args['--windows']) {
   scriptName = 'test:ci:windows'
 }
 
+if (args['--record']) {
+  // assuming that every package.json has script with ":record" suffix
+  scriptName += ':record'
+}
+
 console.log('script name "%s"', scriptName)
 
 const getExamples = () => {
@@ -109,11 +114,6 @@ const testExample = (folder) => {
 
   const npmArgs = ['run', scriptName]
   const npmOptions = { stdio: 'inherit', cwd: folder }
-
-  if (args['--record']) {
-    npmArgs.push('--')
-    npmArgs.push('--record')
-  }
 
   return execa('npm', npmArgs, npmOptions)
 }


### PR DESCRIPTION
trying to see images for flaky tests on AppVeyor 
- closes #527 by increasing default command timeout

TODO: check that all these projects are running and recording

 - [x] examples/blogs__application-actions
 - [x] examples/blogs__e2e-api-testing
 - [x] examples/file-upload-react
 - [x] examples/fundamentals__dynamic-tests
 - [x] examples/fundamentals__fixtures
 - [x] examples/fundamentals__node-modules
 - [x] examples/testing-dom__lit-element
 - [x] examples/unit-testing__application-code
 - [x] examples/unit-testing__react
 - [x] examples/unit-testing__react-apollo
 - [x] examples/unit-testing__react-skeleton

