### PR TITLE
Sometimes CSS interception works, sometimes does not

### DIFF
--- a/examples/stubbing-spying__route2/cypress/integration/stub-fetch-spec.js
+++ b/examples/stubbing-spying__route2/cypress/integration/stub-fetch-spec.js
@@ -184,11 +184,14 @@ describe('route2', () => {
 
     describe('CSS', () => {
       // NOTE: does it work? Sometimes it does, sometimes it does not
-      it.skip('highlights LI elements using injected CSS', () => {
+      it('highlights LI elements using injected CSS', () => {
         // let's intercept the stylesheet the application is loading
         // to highlight list items with a border
         cy.route2('styles.css', (req) => {
           req.reply((res) => {
+            console.log('server sent styles')
+            console.log(res.body) // empty?
+
             res.send(`${res.body}
               li {
                 border: 1px solid pink;

--- a/examples/stubbing-spying__route2/cypress/integration/stub-fetch-spec.js
+++ b/examples/stubbing-spying__route2/cypress/integration/stub-fetch-spec.js
@@ -183,15 +183,18 @@ describe('route2', () => {
     })
 
     describe('CSS', () => {
-      // NOTE: does it work? Sometimes it does, sometimes it does not
       it('highlights LI elements using injected CSS', () => {
         // let's intercept the stylesheet the application is loading
         // to highlight list items with a border
         cy.route2('styles.css', (req) => {
-          req.reply((res) => {
-            console.log('server sent styles')
-            console.log(res.body) // empty?
+          // to avoid caching responses and the server responding
+          // with nothing (because the resource has not changed)
+          // and force the server to send the CSS file
+          // delete caching headers from the request
+          delete req.headers['if-modified-since']
+          delete req.headers['if-none-match']
 
+          req.reply((res) => {
             res.send(`${res.body}
               li {
                 border: 1px solid pink;


### PR DESCRIPTION
using cy.route2 in file examples/stubbing-spying__route2/cypress/integration/stub-fetch-spec.js
to add CSS to `styles.css` used by the app

Sometimes it works

<img width="1279" alt="Screen Shot 2020-09-29 at 3 28 27 PM" src="https://user-images.githubusercontent.com/2212006/94608513-7ef9fa00-026b-11eb-9ba1-c281d87d0ce0.png">

but other times it does not

<img width="797" alt="Screen Shot 2020-09-29 at 3 38 53 PM" src="https://user-images.githubusercontent.com/2212006/94608540-84efdb00-026b-11eb-9cf3-64334cde5d4d.png">

seems the response body is empty? Maybe caching in the browser?