### PR TITLE
Cypress v5.5.0 release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -444,6 +444,8 @@ all_jobs: &all_jobs
       requires:
         - build
   - stubbing-spying__route2:
+      # make sure there is no flake in cy.route2
+      repeat: 5
       requires:
         - build
   - stubbing-spying__window-print:

--- a/examples/server-communication__xhr-assertions/cypress/integration/spec.js
+++ b/examples/server-communication__xhr-assertions/cypress/integration/spec.js
@@ -17,8 +17,11 @@ describe('XHR', () => {
     // and we can retrieve it using cy.get(<alias>)
     // see https://on.cypress.io/get
 
+    // increase the command timeout, because Ajax request
+    // can take longer on CI than expected
+    cy.get('@post', { timeout: 150000 })
     // tip: log the request object to see everything it has in the console
-    cy.get('@post').then(console.log)
+    .then(console.log)
   })
 
   it('gets the expected response', () => {

--- a/examples/stubbing-spying__route2/cypress/integration/image-spec.js
+++ b/examples/stubbing-spying__route2/cypress/integration/image-spec.js
@@ -38,9 +38,7 @@ describe('route2', () => {
     cy.get('img').invoke('height').should('closeTo', 450, 1)
   })
 
-  // skipping because sometimes crashes
-  // NOTE: https://github.com/cypress-io/cypress/issues/8858
-  it.skip('redirects static image', () => {
+  it('redirects static image', () => {
     // instead of serving an image from a fixture
     // we can redirect the request for the image
     // to another route

--- a/examples/stubbing-spying__route2/cypress/integration/image-spec.js
+++ b/examples/stubbing-spying__route2/cypress/integration/image-spec.js
@@ -5,12 +5,11 @@ describe('route2', () => {
     cy.route2('/images').as('image')
     cy.visit('/pics.html')
     // how to check if the /image route was called once?
+    // @see https://github.com/cypress-io/cypress/issues/8934
     // cy.wait('@image')
   })
 
-  // https://github.com/cypress-io/cypress/issues/8623
-  // NOTE: seems to cause an infinite loop
-  it.skip('stubs a static image', () => {
+  it('stubs a static image', () => {
     // 🐅 -> kenguru
     cy.route2('/images', {
       fixture: 'roo.jpg',
@@ -21,6 +20,22 @@ describe('route2', () => {
     }).as('image')
 
     cy.visit('/pics.html')
+    // we DO see the roo image, but again, just like the test above
+    // cannot wait for it using cy.wait
+  })
+
+  it('stubs a static image using fixture', () => {
+    // 🐅 -> kenguru
+    cy.route2('/images', { fixture: 'roo.jpg' })
+    cy.visit('/pics.html')
+    // we DO see the roo image, but again, just like the test above
+    // cannot wait for it using cy.wait
+
+    // confirm the fixture has loaded by looking at its dimensions
+    // use "closeTo" assertion because sometimes browsers renders
+    // images with subpixel accuracy
+    cy.get('img').invoke('width').should('closeTo', 300, 1)
+    cy.get('img').invoke('height').should('closeTo', 450, 1)
   })
 
   // skipping because sometimes crashes

--- a/examples/stubbing-spying__route2/cypress/integration/image-spec.js
+++ b/examples/stubbing-spying__route2/cypress/integration/image-spec.js
@@ -10,7 +10,7 @@ describe('route2', () => {
   })
 
   it('stubs a static image', () => {
-    // 🐅 -> kenguru
+    // 🐅 -> 🦘
     cy.route2('/images', {
       fixture: 'roo.jpg',
       headers: {
@@ -25,7 +25,7 @@ describe('route2', () => {
   })
 
   it('stubs a static image using fixture', () => {
-    // 🐅 -> kenguru
+    // 🐅 -> 🦘
     cy.route2('/images', { fixture: 'roo.jpg' })
     cy.visit('/pics.html')
     // we DO see the roo image, but again, just like the test above

--- a/package-lock.json
+++ b/package-lock.json
@@ -8655,9 +8655,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.4.0.tgz",
-      "integrity": "sha512-BJR+u3DRSYMqaBS1a3l1rbh5AkMRHugbxcYYzkl+xYlO6dzcJVE8uAhghzVI/hxijCyBg1iuSe4TRp/g1PUg8Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.5.0.tgz",
+      "integrity": "sha512-UHEiTca8AUTevbT2pWkHQlxoHtXmbq+h6Eiu/Mz8DqpNkF98zjTBLv/HFiKJUU5rQzp9EwSWtms33p5TWCJ8tQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -8690,10 +8690,10 @@
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
         "ospath": "^1.2.2",
-        "pretty-bytes": "^5.3.0",
+        "pretty-bytes": "^5.4.1",
         "ramda": "~0.26.1",
         "request-progress": "^3.0.0",
-        "supports-color": "^7.1.0",
+        "supports-color": "^7.2.0",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",
@@ -8888,6 +8888,12 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "pretty-bytes": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+          "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
           "dev": true
         },
         "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "chrome-remote-interface": "0.28.1",
     "console.table": "0.10.0",
     "cy-spok": "1.3.2",
-    "cypress": "5.4.0",
+    "cypress": "5.5.0",
     "cypress-axe": "0.8.1",
     "cypress-expect-n-assertions": "1.0.0",
     "cypress-failed-log": "2.7.0",


### PR DESCRIPTION
updated tests showing Cypress v5.5.0 release. 
Merge only after v5.5.0 release and updating Cypress in package.json

- [x] update route2 example with binary image stub