### PR TITLE
add example offline spec

### DIFF
--- a/examples/stubbing-spying__route2/README.md
+++ b/examples/stubbing-spying__route2/README.md
@@ -5,3 +5,4 @@
 - [stub-fetch-spec.js](cypress/integration/stub-fetch-spec.js) shows how to stub `fetch` calls from the application, or modify the page itself, or change the CSS requested by the page
 - [image-spec.js](cypress/integration/image-spec.js) shows how to spy and stub static resources like images
 - [matching-spec.js](cypress/integration/matching-spec.js) shows how the same request can match multiple `cy.route2` matchers
+- [offline-spec.js](cypress/integration/offline-spec.js) emulates offline network connection using CDP and tests how the application handles it

--- a/examples/stubbing-spying__route2/app.js
+++ b/examples/stubbing-spying__route2/app.js
@@ -1,4 +1,4 @@
-/* global document, fetch */
+/* global window, document, fetch */
 /* eslint-disable no-console */
 function updateFavoriteFruits (contents) {
   if (typeof contents !== 'string') {
@@ -38,6 +38,8 @@ setInterval(getFavoriteFruits, 30000)
 
 document.getElementById('load-users').addEventListener('click', () => {
   console.log('loading users')
+  document.querySelector('#users').innerText = ''
+
   fetch('https://jsonplaceholder.cypress.io/users?_limit=3')
   .then((r) => r.json())
   .then((users) => {
@@ -49,4 +51,19 @@ document.getElementById('load-users').addEventListener('click', () => {
 
     document.querySelector('#users').innerHTML = usersHtml
   })
+  .catch((e) => {
+    console.error('problem fetching users', e)
+    document.querySelector('#users').innerText = `Problem fetching users ${e.message}`
+  })
 })
+
+const updateNetworkStatus = () => {
+  const el = document.getElementById('network-status')
+  const text = window.navigator.onLine ? '🟢 online' : '🟥 offline'
+
+  el.innerText = text
+}
+
+updateNetworkStatus()
+window.addEventListener('offline', updateNetworkStatus)
+window.addEventListener('online', updateNetworkStatus)

--- a/examples/stubbing-spying__route2/cypress/integration/offline-spec.js
+++ b/examples/stubbing-spying__route2/cypress/integration/offline-spec.js
@@ -1,0 +1,84 @@
+/// <reference types="cypress" />
+
+/* eslint-env browser */
+
+describe('route2', () => {
+  // since we are using Chrome debugger protocol API
+  // we should only run these tests when NOT in Firefox browser
+  context('app', { browser: '!firefox' }, () => {
+    // https://caniuse.com/online-status
+    const assertOnline = () => {
+      return cy.wrap(window).its('navigator.onLine').should('be.true')
+    }
+    const assertOffline = () => {
+      return cy.wrap(window).its('navigator.onLine').should('be.false')
+    }
+
+    const goOffline = () => {
+      cy.log('**offline**')
+      .then(() => {
+        return Cypress.automation('remote:debugger:protocol',
+          {
+            command: 'Network.emulateNetworkConditions',
+            params: {
+              offline: true,
+              latency: -1,
+              downloadThroughput: -1,
+              uploadThroughput: -1,
+            },
+          })
+      })
+    }
+
+    const goOnline = () => {
+      // disable offline mode, otherwise we will break our tests :)
+      cy.log('**online**')
+      .then(() => {
+        // https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-emulateNetworkConditions
+        return Cypress.automation('remote:debugger:protocol',
+          {
+            command: 'Network.emulateNetworkConditions',
+            params: {
+              offline: false,
+              latency: -1,
+              downloadThroughput: -1,
+              uploadThroughput: -1,
+            },
+          })
+      })
+    }
+
+    // make sure we get back online, even if a test fails
+    // otherwise the Cypress can lose the browser connection
+    beforeEach(goOnline)
+    afterEach(goOnline)
+
+    it('shows error message when offline', () => {
+      assertOnline()
+
+      const url = 'https://jsonplaceholder.cypress.io/users'
+
+      cy.route2(url).as('users')
+
+      cy.visit('/')
+
+      assertOnline()
+
+      // since this call returns a promise, must tell Cypress to wait
+      // for it to be resolved
+      goOffline()
+
+      assertOffline()
+
+      // let's spy on the "fetch" method the app calls
+      cy.window().then((w) => cy.spy(w, 'fetch').withArgs(`${url}?_limit=3`).as('fetchUsers'))
+      cy.get('#load-users').click()
+
+      cy.get('@fetchUsers').should('have.been.calledOnce')
+
+      // the cy.route2 network call does NOT happen
+      // because the browser does not fire it
+      // and thus our network proxy does not see it
+    })
+  })
+})

--- a/examples/stubbing-spying__route2/index.html
+++ b/examples/stubbing-spying__route2/index.html
@@ -14,6 +14,8 @@
   <ul id="users"></ul>
   <button id="load-users">Load users</button>
 
+  <aside id="network-status" />
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/examples/stubbing-spying__route2/index.html
+++ b/examples/stubbing-spying__route2/index.html
@@ -14,7 +14,7 @@
   <ul id="users"></ul>
   <button id="load-users">Load users</button>
 
-  <aside id="network-status" />
+  <aside id="network-status"></aside>
 
   <script src="app.js"></script>
 </body>

--- a/examples/stubbing-spying__route2/page2.html
+++ b/examples/stubbing-spying__route2/page2.html
@@ -16,6 +16,7 @@
   <ul id="users"></ul>
   <button id="load-users">Load users</button>
 
+  <aside id="network-status"></aside>
   <script src="app.js"></script>
 </body>
 

--- a/examples/stubbing-spying__route2/styles.css
+++ b/examples/stubbing-spying__route2/styles.css
@@ -15,6 +15,12 @@ h1 {
   padding-bottom: 20px;
 }
 
+#network-status {
+  position: absolute;
+  bottom: 2em;
+  right: 1em;
+}
+
 /* Source: https://github.com/lukehaas/css-loaders */
 .loader,
 .loader:after {


### PR DESCRIPTION
- closes #580

`navigator.onLine` test is working correctly

![online-offline](https://user-images.githubusercontent.com/2212006/97927621-5619c880-1d33-11eb-94d0-100d40a4c452.gif)


## Problem

Seems the offline network is only working when DevTools is open (in Electron), while `window.navigator.onLine` does change in both cases (DevTools is open or closed)

![says-offline-but-request-happens](https://user-images.githubusercontent.com/2212006/97926360-fe7a5d80-1d30-11eb-8be3-be08e2a71b95.gif)

Opened https://github.com/cypress-io/cypress/issues/9063 for this