### PR TITLE
bump Cypress to v6.2.1

### DIFF
--- a/examples/stubbing-spying__intercept/README.md
+++ b/examples/stubbing-spying__intercept/README.md
@@ -2,7 +2,7 @@
 
 - [control-clock-spec.js](cypress/integration/control-clock-spec.js) shows how to reply with different responses to an ajax request
 - [spy-on-fetch-spec.js](cypress/integration/spy-on-fetch-spec.js) shows how to spy on the `fetch` call
-- [stub-fetch-spec.js](cypress/integration/stub-fetch-spec.js) shows how to stub `fetch` calls from the application, or modify the page itself, or change the CSS requested by the page
+- [stub-fetch-spec.js](cypress/integration/stub-fetch-spec.js) shows how to stub `fetch` calls from the application, or modify the page itself, or change the CSS requested by the page. Shows how to stub or spy the call depending on the object sent
 - [image-spec.js](cypress/integration/image-spec.js) shows how to spy and stub static resources like images
 - [matching-spec.js](cypress/integration/matching-spec.js) shows how the same request can match multiple `cy.intercept` matchers
 - [redirect-spec.js](cypress/integration/redirect-spec.js) shows how to spy on a redirect, and how to stub the redirect response from the server to avoid loading a second domain, for example

--- a/examples/stubbing-spying__intercept/cypress.json
+++ b/examples/stubbing-spying__intercept/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:7080",
   "ignoreTestFiles": "deferred.js",
   "pluginsFile": false,
-  "supportFile": false
+  "supportFile": false,
+  "defaultCommandTimeout": 8000
 }

--- a/examples/stubbing-spying__intercept/cypress/integration/stub-fetch-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/stub-fetch-spec.js
@@ -4,8 +4,6 @@ describe('intercept', () => {
   context('stubbing', function () {
     it('shows no Response message', () => {
       // stub server response with []
-      // for now have to stringify empty arrays
-      // https://github.com/cypress-io/cypress/issues/8532
       cy.intercept('/favorite-fruits', [])
       cy.visit('/')
       cy.contains('No favorites').should('be.visible')
@@ -276,6 +274,22 @@ describe('intercept', () => {
         cy.visit('/')
         cy.contains('footer', 'Cypress test').should('be.visible')
       })
+    })
+
+    it('stub or spy depending on the object sent', () => {
+      cy.visit('/')
+      cy.intercept('POST', '/users', (req) => {
+        // inspect the request to decide if we want to mock it or not
+        if (req.body.id === 101) {
+          // ok, let's stub it, the server usually responds with the same object
+          return req.reply(req.body)
+        }
+        // if we do not call req.reply, then the request goes to the server
+        // and we can still spy on it
+      }).as('postUser')
+
+      cy.get('#post-user').click()
+      cy.wait('@postUser')
     })
   })
 })

--- a/examples/stubbing-spying__intercept/cypress/integration/stub-fetch-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/stub-fetch-spec.js
@@ -284,12 +284,45 @@ describe('intercept', () => {
           // ok, let's stub it, the server usually responds with the same object
           return req.reply(req.body)
         }
+
         // if we do not call req.reply, then the request goes to the server
         // and we can still spy on it
       }).as('postUser')
 
       cy.get('#post-user').click()
       cy.wait('@postUser')
+    })
+
+    it('reports any errors from the intercept as user application errors', () => {
+      cy.visit('/')
+
+      const errorMessage = 'Intercept gone wrong!'
+
+      cy.intercept('POST', '/users', () => {
+        // imagine we have an error in our intercept logic
+        // it will fail the test
+        throw new Error(errorMessage)
+      })
+
+      cy.on('uncaught:exception', (e) => {
+        const text = 'The following error originated from your test code, not from Cypress.'
+
+        if (!e.message.includes(text)) {
+          // hmm, unexpected error text
+          // return and fail the test
+          return
+        }
+
+        if (e.message.includes(errorMessage)) {
+          console.log('caught expected error')
+
+          return false
+        }
+
+        return true
+      })
+
+      cy.get('#post-user').click()
     })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -8639,9 +8639,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.0.tgz",
-      "integrity": "sha512-m/rkcogYM9MTy8rbsZgyS5wT2L/J+B5V2bY2ztkDNMyqhk/oZgUF4KTWVLzkW2I+scg0iAddca95tLlt7XnAtw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.1.tgz",
+      "integrity": "sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -8889,9 +8889,9 @@
           "dev": true
         },
         "pretty-bytes": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-          "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+          "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
           "dev": true
         },
         "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "common-tags": "1.8.0",
     "console.table": "0.10.0",
     "cy-spok": "1.3.2",
-    "cypress": "6.2.0",
+    "cypress": "6.2.1",
     "cypress-axe": "0.12.0",
     "cypress-expect-n-assertions": "1.0.0",
     "cypress-failed-log": "2.9.0",

--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,6 @@
   "major": {
     "automerge": false
   },
-  "minor": {
-    "automerge": false
-  },
   "prConcurrentLimit": 3,
   "prHourlyLimit": 2,
   "rangeStrategy": "pin",


### PR DESCRIPTION
- upgrade Cypress to the latest version
- added an example of stubbing using `cy.intercept` that inspects the request object
- added a test that shows how Cypress reports any errors thrown from the intercept's code