### PR TITLE
how to deal with cached network calls

### DIFF
--- a/examples/stubbing-spying__intercept/app.js
+++ b/examples/stubbing-spying__intercept/app.js
@@ -131,6 +131,26 @@ if (updateUserButton) {
   updateUserButton.addEventListener('click', putUser)
 }
 
+const getCachedUser = document.getElementById('get-cached-user')
+
+if (getCachedUser) {
+  getCachedUser.addEventListener('click', () => {
+    document.querySelector('#users').innerText = ''
+
+    fetch(`/cached-user`)
+    .then((r) => r.json())
+    .then((user) => {
+      const usersHtml = `<div class="user">${user.name}, ${user.occupation}</div>`
+
+      document.querySelector('#users').innerHTML = usersHtml
+    })
+    .catch((e) => {
+      console.error('problem fetching users', e)
+      document.querySelector('#users').innerText = `Problem fetching user ${e.message}`
+    })
+  })
+}
+
 const updateNetworkStatus = () => {
   const el = document.getElementById('network-status')
   const text = window.navigator.onLine ? '🟢 online' : '🟥 offline'

--- a/examples/stubbing-spying__intercept/cypress/integration/stub-cached-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/stub-cached-spec.js
@@ -1,0 +1,19 @@
+/// <reference types="Cypress" />
+/* eslint-disable no-console */
+describe('intercept the cached resource', () => {
+  // NOTE: only works when the DevTools has network "disable cache" checked
+  it.skip('by default does not see request', () => {
+    cy.visit('/')
+    // intercept the network traffic outside the browser
+    cy.intercept({
+      pathname: '/cached-user',
+    }).as('cachedUser')
+
+    // to confirm the call happens, spy on the fetch method
+    cy.window().then((win) => cy.spy(win, 'fetch').as('fetch'))
+
+    cy.get('button#get-cached-user').click()
+    cy.get('@fetch').should('have.been.calledOnce')
+    cy.wait('@cachedUser')
+  })
+})

--- a/examples/stubbing-spying__intercept/index.html
+++ b/examples/stubbing-spying__intercept/index.html
@@ -22,6 +22,9 @@
 
   <button id="put-user">Update user</button>
 
+  <br/>
+  <button id="get-cached-user">Cached user</button>
+
   <aside id="network-status"></aside>
 
   <script src="app.js"></script>

--- a/examples/stubbing-spying__intercept/server.js
+++ b/examples/stubbing-spying__intercept/server.js
@@ -45,4 +45,15 @@ app.get('/getout', (req, res) => {
   res.redirect('https://www.cypress.io')
 })
 
+app.get('/cached-user', (req, res) => {
+  console.log('returning JSON user to cache in the browser')
+  const user = {
+    name: 'Joe',
+    occupation: 'designer',
+  }
+
+  res.set('cache-control', 'private, max-age=600')
+  res.json(user)
+})
+
 app.listen(port)


### PR DESCRIPTION
investigating what advice we can give to https://github.com/cypress-io/cypress/issues/14459 - when the resource arrives with cache header, and the browser simply does not make a request reaching the intercept

Working with "Disable cache" in Network tab of Devtools

<img width="1278" alt="Screen Shot 2021-01-08 at 3 21 46 PM" src="https://user-images.githubusercontent.com/2212006/104060928-a85ce700-51c5-11eb-940d-349425c83cdc.png">

NOT working, because the request does not leave the browser

<img width="1279" alt="Screen Shot 2021-01-08 at 3 22 05 PM" src="https://user-images.githubusercontent.com/2212006/104061007-c75b7900-51c5-11eb-8220-2476daa2152e.png">
