### PR TITLE
chore: Remove automation in downloads recipe

### DIFF
--- a/examples/testing-dom__download/cypress/integration/spec.js
+++ b/examples/testing-dom__download/cypress/integration/spec.js
@@ -93,24 +93,6 @@ describe('file download', () => {
     cy.task('validateZipFile', downloadedFilename)
   }
 
-  beforeEach(() => {
-    // The next command allow downloads in Electron, Chrome, and Edge
-    // without any users popups or file save dialogs.
-    if (!Cypress.isBrowser('firefox')) {
-      // since this call returns a promise, must tell Cypress to wait
-      // for it to be resolved
-      cy.log('Page.setDownloadBehavior')
-      cy.wrap(
-        Cypress.automation('remote:debugger:protocol',
-          {
-            command: 'Page.setDownloadBehavior',
-            params: { behavior: 'allow', downloadPath: downloadsFolder },
-          }),
-        { log: false }
-      )
-    }
-  })
-
   context('from local domain localhost:8070', () => {
     it('CSV file', () => {
       cy.visit('/')


### PR DESCRIPTION
It's no longer necessary with 6.3.0 downloads support.
