### PR TITLE
fix: abort-request example.

### DIFF
--- a/examples/stubbing-spying__intercept/app.js
+++ b/examples/stubbing-spying__intercept/app.js
@@ -159,7 +159,9 @@ function abortAndRequestAgain () {
   xhr.responseType = 'json'
   xhr.send()
   xhr.onload = () => {
-    document.body.innerHTML += `<pre>${JSON.stringify(xhr.response)}</pre>`
+    const status = document.getElementById('network-status')
+
+    status.innerHTML += `<pre>${JSON.stringify(xhr.response)}</pre>`
   }
 }
 const abortButton = document.getElementById('aborted-request')


### PR DESCRIPTION
I found out that there was an error in the test. So, I published the PR here. 

In the test `app.js`, the test result is appended like below:

```js
xhr.onload = () => {
  document.body.innerHTML += `<pre>${JSON.stringify(xhr.response)}</pre>`
}
```

The problem of this code is that the browser parses new HTML string created with `+=` operator and generates the elements behind the scene. Because of that, the event handler, `abortAndRequestAgain()`, is not attached to the new `abort request` button and it is not fired when the button is clicked the second time. And it means there was nothing to wait for. So, the second `wait` failed. 

To solved this problem, I changed the code like below:

```js
xhr.onload = () => {
  const status = document.getElementById('network-status')

  status.innerHTML += `<pre>${JSON.stringify(xhr.response)}</pre>`
}
```

It only changes the code inside `network-status` element. It does not regenerate `abort request` button.