### PR TITLE
add plugin file and enable ping flag in Firefox

### DIFF
--- a/examples/stubbing-spying__intercept/cypress.json
+++ b/examples/stubbing-spying__intercept/cypress.json
@@ -1,7 +1,6 @@
 {
   "baseUrl": "http://localhost:7080",
   "ignoreTestFiles": "deferred.js",
-  "pluginsFile": false,
   "supportFile": false,
   "defaultCommandTimeout": 8000
 }

--- a/examples/stubbing-spying__intercept/cypress/integration/ping-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/ping-spec.js
@@ -1,6 +1,8 @@
 /// <reference types="Cypress" />
 // <a ping="..."> syntax is behind a flag in Firefox
-describe('intercept', { browser: '!firefox' }, () => {
+// https://caniuse.com/?search=anchor%20ping
+// Thus make sure to enable it in the plugin file via the browser launch options
+describe('intercept', () => {
   it('stubs anchor ping', () => {
     cy.visit('/')
     cy.intercept({

--- a/examples/stubbing-spying__intercept/cypress/plugins/index.js
+++ b/examples/stubbing-spying__intercept/cypress/plugins/index.js
@@ -1,0 +1,14 @@
+module.exports = (on, config) => {
+  on('before:browser:launch', (browser = {}, launchOptions) => {
+    if (browser.family === 'firefox') {
+      // One of the tests uses <a ping="..."> feature that
+      // is behind a flag in Firefox browser.
+      // We can programmatically enable an option
+      // in Firefox using launch options
+      launchOptions.preferences['browser.send_pings'] = true
+    }
+
+    // whatever you return here becomes the launchOptions
+    return launchOptions
+  })
+}


### PR DESCRIPTION
- make the anchor ping test work in Firefox browser
- good example of setting a preference when launching Firefox