### PR TITLE
add CSV file download via location.href failing test

### DIFF
--- a/examples/testing-dom__download/cypress.json
+++ b/examples/testing-dom__download/cypress.json
@@ -4,5 +4,6 @@
   "viewportWidth": 500,
   "viewportHeight": 900,
   "baseUrl": "http://localhost:8070",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "pageLoadTimeout": 5000
 }

--- a/examples/testing-dom__download/cypress/integration/spec.js
+++ b/examples/testing-dom__download/cypress/integration/spec.js
@@ -260,6 +260,13 @@ describe('file download', () => {
     })
   })
 
+  context('from location.href', () => {
+    it('CSV file', () => {
+      cy.visit('/')
+      cy.get('[data-cy=download-csv-href]').click()
+    })
+  })
+
   it('finds file', { browser: '!firefox', retries: 1 }, () => {
     // imagine we do not know the exact filename after download
     // so let's call a task to find the file on disk before verifying it

--- a/examples/testing-dom__download/cypress/integration/spec.js
+++ b/examples/testing-dom__download/cypress/integration/spec.js
@@ -260,10 +260,92 @@ describe('file download', () => {
     })
   })
 
-  context('from location.href', () => {
-    it('CSV file', () => {
+  context('using location.href', () => {
+    // NOTE: test times out because the browser stays on the CSV file URL
+    it.skip('CSV file', () => {
       cy.visit('/')
       cy.get('[data-cy=download-csv-href]').click()
+    })
+
+    it('CSV file becomes the document after download', () => {
+      cy.visit('/')
+      cy.intercept('GET', '*.csv', (req) => {
+        req.reply((res) => {
+          // show the CSV as plain text in the browser
+          res.headers['content-type'] = 'text/html; charset=utf-8'
+          res.send(res.body)
+        })
+      })
+
+      cy.get('[data-cy=download-csv-href]').click()
+      // the actual CSV file is NOT downloaded
+      // the browser shows the CSV file url
+      cy.location('pathname').should('be.equal', '/records.csv')
+      // the contents of the CSV file is shown
+      cy.contains('Adam').should('be.visible')
+      // now that we have seen the CSV contents,
+      // we can get back to the original HTML page
+      cy.go('back')
+    })
+
+    it('CSV file intercept', () => {
+      cy.visit('/')
+      // we will set the CSV file contents in this variable
+      let csv
+
+      cy.intercept('GET', '*.csv', (req) => {
+        req.reply((res) => {
+          csv = res.body
+          // redirect the browser back to the original page
+          res.headers.location = '/'
+          res.send(302)
+        })
+      })
+      .as('csvDownload')
+
+      cy.get('[data-cy=download-csv-href]').click()
+      cy.wait('@csvDownload')
+      // we should stay on the original URL
+      cy.location('pathname').should('be.equal', '/')
+      .then(() => {
+        // by now the CSV variable should have CSV text
+        cy.wrap(csv)
+      })
+      .then(neatCSV)
+      .then(validateCsvList)
+    })
+
+    it('CSV file downloaded via cy.request', () => {
+      cy.visit('/')
+      let downloadUrl
+
+      cy.intercept('GET', '*.csv', (req) => {
+        downloadUrl = req.url
+        req.reply({
+          statusCode: 302,
+          location: '/',
+        })
+      })
+
+      cy.get('[data-cy=download-csv-href]').click()
+      .should(() => {
+        // retries until the intercept sets the download URL
+        expect(downloadUrl).to.be.a('string')
+      })
+      .then(() => {
+        // download URL ourselves and save as a file
+        cy.request(downloadUrl).its('body').then((csv) => {
+          // save so we have it as an artifact
+          cy.writeFile('./cypress/downloads/records.csv', csv, 'utf8')
+          .then(() => {
+            // return CSV text for processing
+            return csv
+          })
+        })
+        // convert into a list and verify
+        .then(neatCSV)
+        .then(validateCsvList)
+      })
     })
   })
 

--- a/examples/testing-dom__download/public/app.js
+++ b/examples/testing-dom__download/public/app.js
@@ -1,0 +1,6 @@
+/* global document */
+/* eslint-disable no-console */
+document.querySelector('[data-cy=download-csv-href]').addEventListener('click', () => {
+  console.log('about to download CSV file')
+  document.location.href = 'records.csv'
+})

--- a/examples/testing-dom__download/public/index.html
+++ b/examples/testing-dom__download/public/index.html
@@ -1,4 +1,7 @@
 <body>
+  <p>The first group of examples uses <code>download</code> anchor attribute
+    to prompt file download</p>
+
   <h3>Download CSV</h3>
   <!-- when the user clicks on this link, the file save dialog appears -->
   <a data-cy="download-csv" href="records.csv" download>records.csv</a>
@@ -14,6 +17,9 @@
 
   <h3>Download ZIP file</h3>
   <a data-cy="download-zip" href="files.zip" download>files.zip</a>
+
+  <p>The next group of examples uses <code>download</code> anchor attribute
+    to prompt file download from a remote domain</p>
 
   <h3>Download a remote CSV file</h3>
   <a data-cy="download-remote-csv" href="http://localhost:9000/records.csv" download>remote records.csv</a>
@@ -33,8 +39,15 @@
   <h3>Download a remote ZIP file</h3>
   <a data-cy="download-remote-zip" href="http://localhost:9000/files.zip" download>remote files.zip</a>
 
+  <p>Down load the file by prompting form submit</p>
   <h3>Download from a form</h3>
   <form method="get" action="records.csv">
     <button data-cy="download-form-csv" type="submit">records.csv</button>
   </form>
+
+  <p>Download files by setting the <code>document.location.href</code></p>
+  <h3>Download CSV via location HREF</h3>
+  <button data-cy="download-csv-href">Download CSV</button>
+
+  <script src="app.js"></script>
 </body>


### PR DESCRIPTION
- closes #650
- shows how to handle file download when the app uses `document.location.href = ...` to set the file URL, mostly different workarounds via `cy.intercept`

If this PR merges, then will look at the other file types.