### PR TITLE
correct wrong comment - password is invalid.

### DIFF
--- a/examples/logging-in__jwt/cypress/integration/using-ui-spec.js
+++ b/examples/logging-in__jwt/cypress/integration/using-ui-spec.js
@@ -50,7 +50,7 @@ describe('logs in', () => {
     cy.visit('/')
     cy.location('pathname').should('equal', '/login')
 
-    // enter valid username and password
+    // enter username with invalid password
     cy.get('[name=username]').type('username')
     cy.get('[name=password]').type('wrong-password')
     cy.contains('button', 'Login').click()


### PR DESCRIPTION
corrects comment to say that example uses invalid password