### PR TITLE
fix: remove deprecated stub usage

### DIFF
--- a/examples/stubbing-spying__navigator/cypress/integration/spec.js
+++ b/examples/stubbing-spying__navigator/cypress/integration/spec.js
@@ -5,7 +5,7 @@ context('Navigator', () => {
       cy.visit('index.html', {
         onBeforeLoad (win) {
           // stub property using https://on.cypress.io/stub
-          cy.stub(win.navigator, 'cookieEnabled', false)
+          cy.stub(win.navigator, 'cookieEnabled').value(false)
         },
       })
 


### PR DESCRIPTION
the current version is deprecated and ts complains when you try to use it. Proposed is simply making use of `.value` method

```ts
 cy.stub(win.navigator, 'cookieEnabled').value(false)
```