### PR TITLE
add PDF validation example

### DIFF
--- a/examples/blogs__iframes/package.json
+++ b/examples/blogs__iframes/package.json
@@ -2,6 +2,7 @@
   "name": "iframes",
   "version": "1.0.0",
   "description": "Interacting with iframes",
+  "private": true,
   "scripts": {
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",

--- a/examples/testing-dom__download/README.md
+++ b/examples/testing-dom__download/README.md
@@ -8,6 +8,7 @@
 - a TXT file
 - a JS file
 - a Zip file
+- a PDF file
 
 Spec file | Description
 ---|---

--- a/examples/testing-dom__download/cypress/integration/local-download-spec.js
+++ b/examples/testing-dom__download/cypress/integration/local-download-spec.js
@@ -98,6 +98,14 @@ describe('file download', () => {
 
       cy.log('**confirm downloaded PDF**')
       validateBinaryFile('why-cypress.pdf', 97672)
+
+      // let's read PDF in the plugin file and confirm its basics
+      cy.task('readPdf', './cypress/downloads/why-cypress.pdf')
+      // @ts-ignore
+      .then(({ numpages, text }) => {
+        expect(numpages, 'number of PDF pages').to.equal(1)
+        expect(text, 'has expected text').to.include('Why Cypress?')
+      })
     })
   })
 

--- a/examples/testing-dom__download/cypress/integration/local-download-spec.js
+++ b/examples/testing-dom__download/cypress/integration/local-download-spec.js
@@ -156,7 +156,11 @@ describe('file download', () => {
 
       recurse(
         () => cy.task('findFiles', mask),
-        isNonEmptyString
+        isNonEmptyString,
+        {
+          delay: 100, // pause 100ms between tries
+          timeout: 10000, // iterate up to 10 seconds
+        }
       )
       .then((foundImage) => {
         cy.log(`found image ${foundImage}`)

--- a/examples/testing-dom__download/cypress/plugins/index.js
+++ b/examples/testing-dom__download/cypress/plugins/index.js
@@ -1,10 +1,12 @@
 /// <reference types="cypress" />
 /* eslint-disable no-console */
-const readXlsxFile = require('read-excel-file/node')
 const AdmZip = require('adm-zip')
 const { stripIndent } = require('common-tags')
 const globby = require('globby')
 const { rmdir } = require('fs')
+
+const { readExcelFile } = require('./read-excel')
+const { readPdf } = require('./read-pdf')
 
 /**
  * @type {Cypress.PluginConfig}
@@ -15,15 +17,9 @@ module.exports = (on, config) => {
 
   // register utility tasks to read and parse Excel files
   on('task', {
-    readExcelFile (filename) {
-      // we must read the Excel file using Node library
-      // and can return the parsed list to the browser
-      // for the spec code to validate it
-      console.log('reading Excel file %s', filename)
-      console.log('from cwd %s', process.cwd())
+    readExcelFile,
 
-      return readXlsxFile(filename)
-    },
+    readPdf,
 
     validateZipFile (filename) {
       // now let's validate the downloaded ZIP file

--- a/examples/testing-dom__download/cypress/plugins/read-excel.js
+++ b/examples/testing-dom__download/cypress/plugins/read-excel.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-console */
+const readXlsxFile = require('read-excel-file/node')
+
+const readExcelFile = (filename) => {
+  // we must read the Excel file using Node library
+  // and can return the parsed list to the browser
+  // for the spec code to validate it
+  console.log('reading Excel file %s', filename)
+  console.log('from cwd %s', process.cwd())
+
+  return readXlsxFile(filename)
+}
+
+module.exports = { readExcelFile }

--- a/examples/testing-dom__download/cypress/plugins/read-pdf.js
+++ b/examples/testing-dom__download/cypress/plugins/read-pdf.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+
+const fs = require('fs')
+const pdf = require('pdf-parse')
+
+const readPdf = (filename) => {
+  console.log('reading PDF file %s', filename)
+
+  const dataBuffer = fs.readFileSync(filename)
+
+  return pdf(dataBuffer).then(function (data) {
+    return {
+      numpages: data.numpages,
+      text: data.text,
+    }
+  })
+}
+
+module.exports = { readPdf }
+
+if (!module.parent) {
+  const filename = './public/why-cypress.pdf'
+
+  readPdf(filename).then(console.log)
+}

--- a/examples/testing-dom__download/package.json
+++ b/examples/testing-dom__download/package.json
@@ -2,6 +2,7 @@
   "name": "download",
   "version": "1.0.0",
   "description": "Download and validate a file",
+  "private": true,
   "scripts": {
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18850,6 +18850,12 @@
       "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
       "dev": true
     },
+    "node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=",
+      "dev": true
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -20780,6 +20786,16 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
       }
     },
     "pegjs": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "nodemon": "1.18.11",
     "npm-run-all": "4.1.5",
     "parcel-bundler": "1.12.4",
+    "pdf-parse": "1.1.1",
     "pluralize": "7.0.0",
     "pretty-ms": "3.2.0",
     "react-scripts": "3.3.0",


### PR DESCRIPTION
- closes #678 
- uses https://www.npmjs.com/package/pdf-parse to read PDF and grab its text, then the test verifies it