### PR TITLE
add failing spec to delay binary image

### DIFF
--- a/examples/stubbing-spying__intercept/cypress.json
+++ b/examples/stubbing-spying__intercept/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:7080",
   "ignoreTestFiles": "deferred.js",
   "supportFile": false,
-  "defaultCommandTimeout": 8000
+  "defaultCommandTimeout": 8000,
+  "testFiles": "**/*-spec.js"
 }

--- a/examples/stubbing-spying__intercept/cypress/integration/image-delay-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/image-delay-spec.js
@@ -1,0 +1,27 @@
+/// <reference types="Cypress" />
+import { checkImageResolution } from './utils'
+
+const checkTigerImageResolution = checkImageResolution(500, 333)
+
+describe('intercept', () => {
+  // confirm the cy.intercept does not break binary files
+  // NOTE: requires disabled network cache
+  // https://github.com/cypress-io/cypress/issues/15038
+  it('delays loading of the image', () => {
+    cy.intercept({
+      pathname: '/images/tiger.jpg',
+    }, (req) => {
+      req.reply((res) => {
+        // .delay in Cypress v6
+        // .setDelay in Cypress v7
+        res.delay(2000).send()
+      })
+    }).as('image')
+
+    cy.visit('/pics.html')
+    cy.wait('@image')
+
+    cy.get('img[src="images/tiger.jpg"]').should('be.visible')
+    .and(checkTigerImageResolution)
+  })
+})

--- a/examples/stubbing-spying__intercept/cypress/integration/image-delay-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/image-delay-spec.js
@@ -4,6 +4,15 @@ import { checkImageResolution } from './utils'
 const checkTigerImageResolution = checkImageResolution(500, 333)
 
 describe('intercept', () => {
+  let tigerImageSizeBytes
+
+  before(() => {
+    cy.readFile('./images/tiger.jpg', 'binary').its('length').then((bytes) => {
+      expect(bytes, 'tiger image bytes').to.be.gt(10000)
+      tigerImageSizeBytes = bytes
+    })
+  })
+
   // confirm the cy.intercept does not break binary files
   // NOTE: requires disabled network cache
   // https://github.com/cypress-io/cypress/issues/15038
@@ -14,7 +23,9 @@ describe('intercept', () => {
       req.reply((res) => {
         // .delay in Cypress v6
         // .setDelay in Cypress v7
-        res.delay(2000).send()
+        expect(res.statusCode).to.equal(200)
+        expect(res.body.byteLength).to.equal(tigerImageSizeBytes)
+        res.setDelay(2000)
       })
     }).as('image')
 

--- a/examples/stubbing-spying__intercept/cypress/integration/image-spec.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/image-spec.js
@@ -1,4 +1,5 @@
 /// <reference types="Cypress" />
+import { checkImageResolution } from './utils'
 
 describe('intercept', () => {
   it('spies on loading a static image', () => {
@@ -15,6 +16,15 @@ describe('intercept', () => {
     cy.intercept('/images').as('image')
     cy.visit('/pics.html')
     cy.wait('@image')
+  })
+
+  const checkTigerImageResolution = checkImageResolution(500, 333)
+  const checkRooImageResolution = checkImageResolution(300, 450)
+
+  it('confirms the image shows', () => {
+    cy.visit('/pics.html')
+    cy.get('img[src="images/tiger.jpg"]').should('be.visible')
+    .and(checkTigerImageResolution)
   })
 
   it('stubs a static image', () => {
@@ -44,6 +54,18 @@ describe('intercept', () => {
     // images with subpixel accuracy
     cy.get('img').invoke('width').should('closeTo', 300, 1)
     cy.get('img').invoke('height').should('closeTo', 450, 1)
+  })
+
+  it('replaces image after delay option', () => {
+    cy.intercept({
+      pathname: '/images/tiger.jpg',
+    }, { fixture: 'roo.jpg', delay: 2000 }).as('image')
+
+    cy.visit('/pics.html')
+    cy.wait('@image')
+
+    cy.get('img[src="images/tiger.jpg"]').should('be.visible')
+    .and(checkRooImageResolution)
   })
 
   it('redirects static image', () => {

--- a/examples/stubbing-spying__intercept/cypress/integration/utils.js
+++ b/examples/stubbing-spying__intercept/cypress/integration/utils.js
@@ -1,0 +1,25 @@
+/**
+ * Returns a function that can be used as a ".should" callback
+ * to verify the loaded image.
+ *
+ * @param {number} w The loaded image should have this width
+ * @param {number} h The loaded image should have this height
+ * @returns
+ */
+export const checkImageResolution = (w = 500, h = 333) => {
+  return ($img) => {
+    expect(w, 'expected width').to.be.gt(0)
+    expect(h, 'expected height').to.be.gt(0)
+
+    // "naturalWidth" and "naturalHeight" are set when the image loads
+    expect(
+      $img[0].naturalWidth,
+      'image width'
+    ).to.equal(w)
+
+    expect(
+      $img[0].naturalHeight,
+      'image height'
+    ).to.equal(h)
+  }
+}


### PR DESCRIPTION
- show the problem with binary resource load delay and `cy.intercept`