### PR TITLE
chore(cypress 7.0): Remove experimentalComponentTesting

### DIFF
--- a/examples/unit-testing__react-apollo/cypress.json
+++ b/examples/unit-testing__react-apollo/cypress.json
@@ -1,5 +1,4 @@
 {
-  "experimentalComponentTesting": true,
   "componentFolder": "src",
   "testFiles": "**/*.spec.jsx"
 }

--- a/examples/unit-testing__react-skeleton/cypress.json
+++ b/examples/unit-testing__react-skeleton/cypress.json
@@ -1,6 +1,5 @@
 {
   "fixturesFolder": false,
-  "experimentalComponentTesting": true,
   "componentFolder": "src",
   "testFiles": "**/*.spec.jsx"
 }

--- a/examples/unit-testing__react/cypress.json
+++ b/examples/unit-testing__react/cypress.json
@@ -1,5 +1,4 @@
 {
   "fixturesFolder": false,
-  "pluginsFile": false,
-  "experimentalComponentTesting": true
+  "pluginsFile": false
 }


### PR DESCRIPTION
This PR removes deprecated flag and fixes CI that fail for. 7.0 binary https://app.circleci.com/pipelines/github/cypress-io/cypress/18812/workflows/823e1ff3-364a-4fb6-bae2-20b6061bdc39/jobs/681349