### PR TITLE
remove Network.disable from offline-spec

### DIFF
--- a/examples/server-communication__offline/cypress/integration/offline-spec.js
+++ b/examples/server-communication__offline/cypress/integration/offline-spec.js
@@ -51,12 +51,6 @@ const goOnline = () => {
         },
       })
   })
-  .then(() => {
-    return Cypress.automation('remote:debugger:protocol',
-      {
-        command: 'Network.disable',
-      })
-  })
 }
 
 // since we are using Chrome debugger protocol API


### PR DESCRIPTION
This breaks https://github.com/cypress-io/cypress/pull/16730 since `Network.disable` stops network events from being received: https://app.circleci.com/pipelines/github/cypress-io/cypress-test-example-repos/8257/workflows/84ef6df2-c864-4c27-9d52-8729f9b6981d/jobs/195214/parallel-runs/10?filterBy=FAILED

Luckily `Network.disable` is not needed for this technique to work.