### PR TITLE
Custom command recipe throws an error

### DIFF
--- a/examples/fundamentals__add-custom-command/README.md
+++ b/examples/fundamentals__add-custom-command/README.md
@@ -11,7 +11,9 @@ You write Cypress custom command, for example for selecting DOM elements by `dat
  *
  * @example cy.dataCy('greeting')
  */
-Cypress.Commands.add('dataCy', (value) => cy.get(`[data-cy=${value}]`))
+Cypress.Commands.add('dataCy', (value) => {
+    cy.get(`[data-cy=${value}]`)
+})
 ```
 
 Yet, TypeScript compiler and IntelliSense do not understand that you have added a new method to the global `cy` object.


### PR DESCRIPTION
See : https://github.com/cypress-io/cypress/issues/18915

An error 'Argument of type '() => void' is not assignable to parameter of type '() => Chainable<any>' throws when you return directly

https://github.com/cypress-io/cypress/issues/18915#issuecomment-971834823
<img width="722" alt="Sans titre" src="https://user-images.githubusercontent.com/15921402/155544860-a00cf335-8d48-4102-aada-d2a89f23c8ed.png">


fixes #763