### PR TITLE
Csp bug in GUI test spec panel / DOM snapshotting

### DIFF
--- a/examples/testing-dom__hover-hidden-elements/mouse.html
+++ b/examples/testing-dom__hover-hidden-elements/mouse.html
@@ -1,14 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
   <title>Hover and Hidden Elements - Mouse</title>
   <script type="text/javascript" src="/node_modules/jquery/dist/jquery.js"></script>
-  <style>
-    #background {
-      padding: 50px;
-      background-color: #eee;
-    }
-  </style>
+  <link rel="stylesheet" type="text/css" href="./styles.css">
 </head>
 <body>
   <h2>
@@ -21,27 +17,6 @@
 
   <ul id="messages"></ul>
 
-  <script type="text/javascript">
-    var $btnJquery   = $("#with-jquery")
-    var btnNoJquery  = $("#no-jquery").get(0)
-    var $msgs        = $("#messages");
-
-    // when our buttons have these mouse events fired on it
-    // we want to populate <p id="message"> with the event
-    ["mouseover", "mouseout", "mouseenter", "mouseleave"].forEach(function(event){
-      var append = function(){
-        // append the <li> message into the messages <ul>
-        var $li = $("<li />").text("the event " + event + " was fired")
-
-        $msgs.append($li)
-      }
-
-      // add native DOM event listener to this button
-      btnNoJquery.addEventListener(event, append)
-
-      // add jquery bound event listener to this button
-      $btnJquery.on(event, append)
-    })
-  </script>
+  <script type="text/javascript" src="./script.js"></script>
 </body>
 </html>

--- a/examples/testing-dom__hover-hidden-elements/script.js
+++ b/examples/testing-dom__hover-hidden-elements/script.js
@@ -1,0 +1,20 @@
+var $btnJquery   = $("#with-jquery")
+var btnNoJquery  = $("#no-jquery").get(0)
+var $msgs        = $("#messages");
+
+// when our buttons have these mouse events fired on it
+// we want to populate <p id="message"> with the event
+["mouseover", "mouseout", "mouseenter", "mouseleave"].forEach(function(event){
+  var append = function(){
+    // append the <li> message into the messages <ul>
+    var $li = $("<li />").text("the event " + event + " was fired")
+
+    $msgs.append($li)
+  }
+
+  // add native DOM event listener to this button
+  btnNoJquery.addEventListener(event, append)
+
+  // add jquery bound event listener to this button
+  $btnJquery.on(event, append)
+})

--- a/examples/testing-dom__hover-hidden-elements/styles.css
+++ b/examples/testing-dom__hover-hidden-elements/styles.css
@@ -1,0 +1,4 @@
+#background {
+    padding: 50px;
+    background-color: #eee;
+}


### PR DESCRIPTION
how test runs without CSP enabled
![Screen Shot 2022-05-06 at 11 32 28 AM](https://user-images.githubusercontent.com/10646951/167188233-842a2ed3-a3ca-4d35-ac8c-37fe419b1bea.png)

test running on csp branch
(NOTICE - STYLES STILL WORK AS LONG AS YOU DONT CLICK TO PIN A SNAPSHOT)
![Screen Shot 2022-05-06 at 11 41 48 AM](https://user-images.githubusercontent.com/10646951/167188331-d8be7cb0-8aec-4108-ae3d-a01dcda298bc.png)

test running on csp branch - once you click on / pin a DOM snapshot from the test spec panel
(NOTICE - STYLES ARE BROKE)
![Screen Shot 2022-05-06 at 11 42 18 AM](https://user-images.githubusercontent.com/10646951/167188484-1f0aa36a-0ab9-48dc-b78e-a70efe5bd02e.png)

