### PR TITLE
Disable offline recipe tests in CI

### DIFF
--- a/examples/server-communication__offline/package.json
+++ b/examples/server-communication__offline/package.json
@@ -8,8 +8,6 @@
     "cypress:run": "../../node_modules/.bin/cypress run",
     "cypress:run:record": "../../node_modules/.bin/cypress run --record",
     "dev": "../../node_modules/.bin/start-test 7080 cypress:open",
-    "start": "../../node_modules/.bin/serve -l 7080 --no-clipboard",
-    "test:ci": "../../node_modules/.bin/start-test 7080 cypress:run",
-    "test:ci:record": "../../node_modules/.bin/start-test 7080 cypress:run:record"
+    "start": "../../node_modules/.bin/serve -l 7080 --no-clipboard"
   }
 }


### PR DESCRIPTION
Related: https://github.com/cypress-io/cypress-example-recipes/issues/772

Disabling these test runs in CI to prevent failures while a different approach is investigated.