### PR TITLE
test: Update failing sort test due to ag-grid release

### DIFF
--- a/examples/testing-dom__sorting-table/cypress/integration/spec.js
+++ b/examples/testing-dom__sorting-table/cypress/integration/spec.js
@@ -11,7 +11,7 @@ describe('Sorting table', () => {
 
     cy.get('#myGrid') // table
     .within(() => {
-      cy.get('[role=rowgroup] .ag-row')
+      cy.get('.ag-center-cols-container[role=rowgroup] .ag-row')
       .should('have.length', 3) // non-header rows
 
       cy.log('**sort by price**')

--- a/examples/testing-dom__sorting-table/index.html
+++ b/examples/testing-dom__sorting-table/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Ag-Grid Basic Example</title>
-  <script src="https://unpkg.com/ag-grid-community@27.2.0/dist/ag-grid-community.min.js"></script>
+  <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.js"></script>
   <script src="main.js"></script>
 </head>
 

--- a/examples/testing-dom__sorting-table/index.html
+++ b/examples/testing-dom__sorting-table/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Ag-Grid Basic Example</title>
-  <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.js"></script>
+  <script src="https://unpkg.com/ag-grid-community@27.2.0/dist/ag-grid-community.min.js"></script>
   <script src="main.js"></script>
 </head>
 

--- a/examples/testing-dom__sorting-table/index.html
+++ b/examples/testing-dom__sorting-table/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Ag-Grid Basic Example</title>
-  <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.js"></script>
+  <script src="https://unpkg.com/ag-grid-community@27.3.0/dist/ag-grid-community.min.js"></script>
   <script src="main.js"></script>
 </head>
 


### PR DESCRIPTION
It looks like the 27.3.0 release of ag-grid introduced additional elements that were throwing off our assertions. Example: https://app.circleci.com/pipelines/github/cypress-io/cypress/38160/workflows/f78c7971-2cba-462a-943f-c49aff9ec254/jobs/1544249?invite=true#step-112-7776

There are now hidden pinned columns on the left and right that include rows matching that in the body, so now there are thrice as many as we are asserting on. 

I pinned the version to limit the impact of future releases of ag-grid. If we'd prefer to stay current, I could update the assertion instead, just let me know.