### PR TITLE
chore: adding e2e sections in cy configs that don't have them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,9 +418,6 @@ all_jobs: &all_jobs
   - blogs__iframes:
       requires:
         - build
-      # investigate flake
-      # https://github.com/cypress-io/cypress-example-recipes/issues/558
-      repeat: 10
   - blogs__application-actions:
       requires:
         - build
@@ -535,8 +532,6 @@ all_jobs: &all_jobs
       requires:
         - build
   - stubbing-spying__intercept:
-      # make sure there is no flake in cy.intercept
-      repeat: 5
       requires:
         - build
   - stubbing-spying__window-print:
@@ -599,7 +594,6 @@ all_jobs: &all_jobs
   - testing-dom__select2:
       requires:
         - build
-      repeat: 5
   - testing-dom__clipboard:
       requires:
         - build

--- a/examples/blogs__a11y/cypress.config.js
+++ b/examples/blogs__a11y/cypress.config.js
@@ -1,5 +1,5 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  e2e: { },
+  e2e: {},
 })

--- a/examples/blogs__a11y/cypress.config.js
+++ b/examples/blogs__a11y/cypress.config.js
@@ -1,3 +1,5 @@
 const { defineConfig } = require('cypress')
 
-module.exports = defineConfig({})
+module.exports = defineConfig({
+  e2e: { },
+})

--- a/examples/blogs__assertion-counting/cypress.config.js
+++ b/examples/blogs__assertion-counting/cypress.config.js
@@ -1,5 +1,5 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
-  e2e: { },
+  e2e: {},
 })

--- a/examples/blogs__assertion-counting/cypress.config.js
+++ b/examples/blogs__assertion-counting/cypress.config.js
@@ -1,3 +1,5 @@
 const { defineConfig } = require('cypress')
 
-module.exports = defineConfig({})
+module.exports = defineConfig({
+  e2e: { },
+})

--- a/examples/blogs__dayjs/cypress.config.js
+++ b/examples/blogs__dayjs/cypress.config.js
@@ -4,4 +4,5 @@ module.exports = defineConfig({
   fixturesFolder: false,
   viewportWidth: 500,
   viewportHeight: 200,
+  e2e: {},
 })

--- a/examples/blogs__iframes/cypress.config.js
+++ b/examples/blogs__iframes/cypress.config.js
@@ -5,7 +5,7 @@ module.exports = defineConfig({
   viewportHeight: 1000,
   fixturesFolder: false,
   retries: {
-    runMode: 5
+    runMode: 5,
   },
   e2e: {},
 })

--- a/examples/blogs__iframes/cypress.config.js
+++ b/examples/blogs__iframes/cypress.config.js
@@ -5,7 +5,7 @@ module.exports = defineConfig({
   viewportHeight: 1000,
   fixturesFolder: false,
   retries: {
-    runMode: 2,
+    runMode: 5,
     openMode: 0,
   },
   e2e: {},

--- a/examples/blogs__iframes/cypress.config.js
+++ b/examples/blogs__iframes/cypress.config.js
@@ -8,4 +8,5 @@ module.exports = defineConfig({
     runMode: 2,
     openMode: 0,
   },
+  e2e: {},
 })

--- a/examples/blogs__iframes/cypress.config.js
+++ b/examples/blogs__iframes/cypress.config.js
@@ -5,8 +5,7 @@ module.exports = defineConfig({
   viewportHeight: 1000,
   fixturesFolder: false,
   retries: {
-    runMode: 5,
-    openMode: 0,
+    runMode: 5
   },
   e2e: {},
 })

--- a/examples/extending-cypress__chai-assertions/cypress.config.js
+++ b/examples/extending-cypress__chai-assertions/cypress.config.js
@@ -2,4 +2,5 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   fixturesFolder: false,
+  e2e: {},
 })

--- a/examples/file-upload-react/cypress.config.js
+++ b/examples/file-upload-react/cypress.config.js
@@ -1,3 +1,5 @@
 const { defineConfig } = require('cypress')
 
-module.exports = defineConfig({})
+module.exports = defineConfig({
+  e2e: {},
+})

--- a/examples/fundamentals__add-custom-command-ts/cypress.config.ts
+++ b/examples/fundamentals__add-custom-command-ts/cypress.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   viewportHeight: 200,
   viewportWidth: 300,
   fixturesFolder: false,
+  e2e: {},
 })

--- a/examples/fundamentals__add-custom-command/cypress.config.js
+++ b/examples/fundamentals__add-custom-command/cypress.config.js
@@ -4,4 +4,5 @@ module.exports = defineConfig({
   viewportHeight: 200,
   viewportWidth: 300,
   fixturesFolder: false,
+  e2e: {},
 })

--- a/examples/fundamentals__fixtures/cypress.config.js
+++ b/examples/fundamentals__fixtures/cypress.config.js
@@ -1,3 +1,5 @@
 const { defineConfig } = require('cypress')
 
-module.exports = defineConfig({})
+module.exports = defineConfig({
+  e2e: {},
+})

--- a/examples/fundamentals__module-api/cypress.config.js
+++ b/examples/fundamentals__module-api/cypress.config.js
@@ -2,4 +2,5 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   fixturesFolder: false,
+  e2e: {},
 })

--- a/examples/fundamentals__node-modules/cypress.config.js
+++ b/examples/fundamentals__node-modules/cypress.config.js
@@ -2,4 +2,5 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   fixturesFolder: false,
+  e2e: {},
 })

--- a/examples/stubbing-spying__intercept/cypress.config.js
+++ b/examples/stubbing-spying__intercept/cypress.config.js
@@ -4,7 +4,7 @@ module.exports = defineConfig({
   defaultCommandTimeout: 8000,
   retries: {
     runMode: 5,
-    openMode: 1,
+    openMode: 0,
   },
   e2e: {
     baseUrl: 'http://localhost:7080',

--- a/examples/stubbing-spying__intercept/cypress.config.js
+++ b/examples/stubbing-spying__intercept/cypress.config.js
@@ -2,6 +2,10 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   defaultCommandTimeout: 8000,
+  retries: {
+    runMode: 5,
+    openMode: 1,
+  },
   e2e: {
     baseUrl: 'http://localhost:7080',
     supportFile: false,

--- a/examples/stubbing-spying__intercept/cypress.config.js
+++ b/examples/stubbing-spying__intercept/cypress.config.js
@@ -4,7 +4,6 @@ module.exports = defineConfig({
   defaultCommandTimeout: 8000,
   retries: {
     runMode: 5,
-    openMode: 0,
   },
   e2e: {
     baseUrl: 'http://localhost:7080',

--- a/examples/testing-dom__select2/cypress.config.js
+++ b/examples/testing-dom__select2/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   defaultCommandTimeout: 3000,
   retries: {
-    runMode: 2,
+    runMode: 5,
     openMode: 0,
   },
   e2e: {

--- a/examples/testing-dom__select2/cypress.config.js
+++ b/examples/testing-dom__select2/cypress.config.js
@@ -4,7 +4,6 @@ module.exports = defineConfig({
   defaultCommandTimeout: 3000,
   retries: {
     runMode: 5,
-    openMode: 0,
   },
   e2e: {
     supportFile: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "common-tags": "1.8.0",
         "console.table": "0.10.0",
         "cy-spok": "1.3.2",
-        "cypress": "10.0.2",
+        "cypress": "10.1.0",
         "cypress-axe": "0.12.2",
         "cypress-expect-n-assertions": "1.0.0",
         "cypress-failed-log": "2.9.1",
@@ -9952,9 +9952,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.2.tgz",
-      "integrity": "sha512-7+C4KHYBcfZrawss+Gt5PlS35rfc6ySc59JcHDVsIMm1E/J35dqE41UEXpdtwIq3549umCerNWnFADzqib4kcA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz",
+      "integrity": "sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -47311,9 +47311,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.2.tgz",
-      "integrity": "sha512-7+C4KHYBcfZrawss+Gt5PlS35rfc6ySc59JcHDVsIMm1E/J35dqE41UEXpdtwIq3549umCerNWnFADzqib4kcA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.1.0.tgz",
+      "integrity": "sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "common-tags": "1.8.0",
     "console.table": "0.10.0",
     "cy-spok": "1.3.2",
-    "cypress": "10.0.2",
+    "cypress": "10.1.0",
     "cypress-axe": "0.12.2",
     "cypress-expect-n-assertions": "1.0.0",
     "cypress-failed-log": "2.9.1",


### PR DESCRIPTION
This PR adds e2e config sections to projects that did not have them. This was causing the ci pipelines to break in Cy 10.1.0 as it now requires there be a e2e or component section when in run mode.

This PR also changes some of the examples to run with retries the the Cypress config instead of using the test-retries scripts. It was unclear on what the script was trying to achieve, and the tests were flaky, so I felt using the built in retries mechanism makes sense.