### PR TITLE
fix: Update async example for Cy 12 changes around .invoke()

### DIFF
--- a/examples/fundamentals__add-custom-command-ts/cypress/e2e/async-command.cy.ts
+++ b/examples/fundamentals__add-custom-command-ts/cypress/e2e/async-command.cy.ts
@@ -4,13 +4,15 @@
 
 Cypress.Commands.add('asyncAdd', (a, b) => {
   cy.log(`${a} + ${b}`)
-  // our application in "index.html" has placed a promise-returning
+
+  // After 1000 ms, our application's index.html adds a promise-returning
   // method "asyncAdd" onto the "window" object.
-  // from the tests's custom command we can invoke that method
-  // Cypress automatically waits for the promises to resolve
-  // before yielding their value to the next command in the test
-  // https://on.cypress.io/invoke
-  cy.window().invoke('asyncAdd', a, b)
+  // .its() waits for this to exist before passing it to .then().
+
+  // .then() in turn automatically waits for the returned promise to resolve
+  // before yielding its value to the next command in the test
+  // https://on.cypress.io/then
+  cy.window().its('asyncAdd').then(add => add(a, b))
 })
 
 describe('example', () => {

--- a/examples/fundamentals__add-custom-command/cypress/e2e/async-command.cy.js
+++ b/examples/fundamentals__add-custom-command/cypress/e2e/async-command.cy.js
@@ -4,13 +4,15 @@
 
 Cypress.Commands.add('asyncAdd', (a, b) => {
   cy.log(`${a} + ${b}`)
-  // our application in "index.html" has placed a promise-returning
+
+  // After 1000 ms, our application's index.html adds a promise-returning
   // method "asyncAdd" onto the "window" object.
-  // from the tests's custom command we can invoke that method
-  // Cypress automatically waits for the promises to resolve
-  // before yielding their value to the next command in the test
-  // https://on.cypress.io/invoke
-  cy.window().invoke('asyncAdd', a, b)
+  // .its() waits for this to exist before passing it to .then().
+
+  // .then() in turn automatically waits for the returned promise to resolve
+  // before yielding its value to the next command in the test
+  // https://on.cypress.io/then
+  cy.window().its('asyncAdd').then((add) => add(a, b))
 })
 
 describe('example', () => {

--- a/examples/testing-dom__clipboard/cypress/e2e/permissions-spec.cy.js
+++ b/examples/testing-dom__clipboard/cypress/e2e/permissions-spec.cy.js
@@ -13,7 +13,7 @@ describe('Clipboard permissions', () => {
     .its('navigator.permissions')
     // permission names taken from
     // https://w3c.github.io/permissions/#enumdef-permissionname
-    .invoke('query', { name: 'clipboard-read' })
+    .then((permissions) => permissions.query({ name: 'clipboard-read' }))
     .its('state')
     .should('equal', 'granted')
   })
@@ -24,7 +24,7 @@ describe('Clipboard permissions', () => {
     .its('navigator.permissions')
     // permission names taken from
     // https://w3c.github.io/permissions/#enumdef-permissionname
-    .invoke('query', { name: 'clipboard-read' })
+    .then((permissions) => permissions.query({ name: 'clipboard-read' }))
     // by default it is "prompt" which shows a popup asking
     // the user if the site can have access to the clipboard
     // if the user allows, then next time it will be "granted"
@@ -54,7 +54,7 @@ describe('Clipboard permissions', () => {
     .its('navigator.permissions')
     // permission names taken from
     // https://w3c.github.io/permissions/#enumdef-permissionname
-    .invoke('query', { name: 'clipboard-read' })
+    .then((permissions) => permissions.query({ name: 'clipboard-read' }))
     .its('state').should('equal', 'granted')
 
     // now reading the clipboard from test will work
@@ -64,7 +64,7 @@ describe('Clipboard permissions', () => {
     cy.get('[aria-label="Copy"]').click()
     // confirm the clipboard's contents
     cy.window().its('navigator.clipboard')
-    .invoke('readText')
+    .then((clip) => clip.readText())
     .should('equal', 'npm install -D cypress')
 
     // TODO how can we paste the clipboard into the text area?

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "common-tags": "1.8.0",
         "console.table": "0.10.0",
         "cy-spok": "1.3.2",
-        "cypress": "10.7.0",
+        "cypress": "https://cdn.cypress.io/beta/npm/12.0.0/linux-x64/release/12.0.0-d7e148f8cde4f74300bec3a3e2fa55ed3139d6fd/cypress.tgz",
         "cypress-axe": "0.12.2",
         "cypress-expect-n-assertions": "1.0.0",
         "cypress-failed-log": "2.9.1",
@@ -141,7 +141,7 @@
         "x2js": "3.4.1"
       },
       "engines": {
-        "node": "16.13.0"
+        "node": "16.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -16444,11 +16444,12 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.7.0.tgz",
-      "integrity": "sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==",
+      "version": "12.0.0",
+      "resolved": "https://cdn.cypress.io/beta/npm/12.0.0/linux-x64/release/12.0.0-d7e148f8cde4f74300bec3a3e2fa55ed3139d6fd/cypress.tgz",
+      "integrity": "sha512-S9cxMnFmZuOmLuuo/tAtET7qeFAwIsKZhqQHV+IeTblfAtuR0DwIAMOhx3zAaR1y+fPetlZf0UZ2weWs23xItw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -16469,7 +16470,7 @@
         "dayjs": "^1.10.4",
         "debug": "^4.3.2",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
@@ -57463,9 +57464,8 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.7.0.tgz",
-      "integrity": "sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==",
+      "version": "https://cdn.cypress.io/beta/npm/12.0.0/linux-x64/release/12.0.0-d7e148f8cde4f74300bec3a3e2fa55ed3139d6fd/cypress.tgz",
+      "integrity": "sha512-S9cxMnFmZuOmLuuo/tAtET7qeFAwIsKZhqQHV+IeTblfAtuR0DwIAMOhx3zAaR1y+fPetlZf0UZ2weWs23xItw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -57487,7 +57487,7 @@
         "dayjs": "^1.10.4",
         "debug": "^4.3.2",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",


### PR DESCRIPTION
In Cypress 12, .invoke() no longer waits for promises to resolve. This example needed updating to work with the new version of .invoke().