### PR TITLE
update selectors for docs and public sites

### DIFF
--- a/examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js
+++ b/examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js
@@ -2,9 +2,9 @@
 describe('Subdomains', () => {
   const urlToLogoSelector = {
     // logo selector at https://docs.cypress.io/
-    'https://docs.cypress.io': 'img[alt="Cypress Docs Logo"]',
+    'https://docs.cypress.io': 'img[alt="Cypress Logo"]',
     // on the public static site, the logo is rendered within a labeled link
-    'https://www.cypress.io': 'a[aria-label="Return to cypress.io homepage"]',
+    'https://www.cypress.io': 'a[aria-label="Cypress"]',
   }
 
   // ignore errors from the site itself

--- a/examples/fundamentals__dynamic-tests/cypress/e2e/viewports-spec.cy.js
+++ b/examples/fundamentals__dynamic-tests/cypress/e2e/viewports-spec.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 describe('Viewports', () => {
   // on the public static site, the logo is rendered within a labeled link
-  const logoSelector = 'a[aria-label="Return to cypress.io homepage"]'
+  const logoSelector = 'a[aria-label="Cypress"]'
 
   // ignore errors from the site itself
   Cypress.on('uncaught:exception', () => {

--- a/examples/server-communication__visit-2nd-domain/cypress/e2e/using-file-spec.cy.js
+++ b/examples/server-communication__visit-2nd-domain/cypress/e2e/using-file-spec.cy.js
@@ -12,14 +12,11 @@ describe('Two domains using file', () => {
     return true
   })
 
-  it('visits 1nd domain', () => {
+  it('visits 1st domain', () => {
     cy.visit('https://www.cypress.io/')
     // there are several GitHub links on the page, make sure
     // to use the selector that returns a single item
-    cy.get('header [aria-label="Check out our github page"]')
-    .should('have.length', 1)
-    // from the jQuery wrapping <a href="https://github.io ..." />
-    // get the "href" value
+    cy.get('[href="https://github.com/cypress-io/cypress"]').first()
     .invoke('attr', 'href')
     .then((url) => {
       expect(url).to.be.a('string')

--- a/examples/server-communication__visit-2nd-domain/cypress/e2e/using-task-spec.cy.js
+++ b/examples/server-communication__visit-2nd-domain/cypress/e2e/using-task-spec.cy.js
@@ -14,10 +14,7 @@ describe('Two domains', () => {
     cy.visit('https://www.cypress.io/')
     // there are several GitHub links on the page, make sure
     // to use the selector that returns a single item
-    cy.get('header [aria-label="Check out our github page"]')
-    .should('have.length', 1)
-    // from the jQuery wrapping <a href="https://github.io ..." />
-    // get the "href" value
+    cy.get('[href="https://github.com/cypress-io/cypress"]').first()
     .invoke('attr', 'href')
     .then((url) => {
       // save the value in the `setupNodeEvents` process


### PR DESCRIPTION
We recently published a new public site and updated our docs site to match. This [broke a couple of the tests](https://app.circleci.com/pipelines/github/cypress-io/cypress/48429/workflows/a30ae111-7ef5-4a9f-b312-249862f7aa75/jobs/2020445) in this repo because the labels for the logos changed. This PR updates the selectors to match what we have on the sites right now.

**Steps to test**:
- run Cypress in open mode
- open e2e testing for `examples/fundamentals__dynamic-tests`
- run `cypress/e2e/subdomains-spec.cy.js` and `cypress/e2e/viewports-spec.cy.js` and make sure that they pass