### PR TITLE
Updates for 13.0 changes around video

### DIFF
--- a/examples/fundamentals__module-api-wrap/cypress/e2e/spec.cy.js
+++ b/examples/fundamentals__module-api-wrap/cypress/e2e/spec.cy.js
@@ -10,7 +10,6 @@ describe('Cypress Run wrap', () => {
 
   it('sets the expected config variables by parsing --config', () => {
     expect(Cypress.config()).to.include({
-      video: false,
       viewportWidth: 100,
       viewportHeight: 300,
     })

--- a/examples/fundamentals__window-size/cypress.config.js
+++ b/examples/fundamentals__window-size/cypress.config.js
@@ -4,6 +4,7 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   fixturesFolder: false,
   e2e: {
+    video: true,
     supportFile: false,
     setupNodeEvents (on, config) {
       // configure plugins here


### PR DESCRIPTION
As part of 13.0, we will be turning off video by default. This PR updates a couple of examples in the recipes so that they will function properly when video is turned off by default.

This PR DOES NOT REQUIRE changes from 13.0 branch in order to merge. It can be merged anytime.