### PR TITLE
fix: tell clipboard-copy-element to be referenced as a module. @see h…

### DIFF
--- a/examples/testing-dom__clipboard/index.html
+++ b/examples/testing-dom__clipboard/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script src="https://unpkg.com/@github/clipboard-copy-element@latest" defer></script>
+  <script type="module" src="https://unpkg.com/@github/clipboard-copy-element@latest" defer></script>
   <script src="https://unpkg.com/tiny-toast@1.2.0/dist/tiny-toast.js" defer></script>
   <style>
     pre {


### PR DESCRIPTION
…ttps://github.com/github/clipboard-copy-element#script

fixes the failing example recipes jobs in cypress-io/cypress. @see https://app.circleci.com/pipelines/github/cypress-io/cypress/53493/workflows/e9c6b9bc-17c8-4c57-ba88-ed616c0aad86/jobs/2206508