### PR TITLE
chore: add glob argument to test-examples script to allow running a subset of tests

### DIFF
--- a/test-examples.js
+++ b/test-examples.js
@@ -28,6 +28,7 @@ const args = arg({
   '--browser': String,
   '--headless': Boolean,
   '--record': Boolean,
+  '--glob': String,
 })
 
 // fill default values
@@ -61,8 +62,8 @@ if (args['--record']) {
 
 console.log('script name "%s"', scriptName)
 
-const getExamples = () => {
-  return globby('examples/*', { onlyFiles: false, expandDirectories: false })
+const getExamples = (glob) => {
+  return globby(glob ? glob : 'examples/*', { onlyFiles: false, expandDirectories: false })
 }
 
 const printFolders = (folders) => {
@@ -191,7 +192,7 @@ const filterByScriptName = (folders) => {
 }
 
 bluebird
-.try(getExamples)
+.try(() => getExamples(args['--glob']))
 .then((list) => list.sort())
 .then(filterByScriptName)
 .then(filterSomeFolders)


### PR DESCRIPTION
Related to https://github.com/cypress-io/cypress/issues/27521

In order to parallelize these tests on Electron in the Cypress repo, we need to be able to run a subset of the example tests. This PR adds a parameter so that we can pass a glob of tests to run. For example
```
npm run test:ci -- --glob "examples/{extending-cypress__*,logging-in__*}"
```
will only run the tests inside of directories starting with `extending-cypress` and `logging-in`. If no glob is passed, then the script behaves the same as it does now and runs all of the specs inside of `examples/`