### PR TITLE
fix: record workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ defaults: &defaults
     test-command:
       description: Custom test command to use to run tests, like "npm run test:ci"
       type: string
-      default: ''
+      default: ""
   parallelism: 1
   working_directory: ~/app
   docker:
@@ -124,7 +124,7 @@ jobs:
     environment:
       TERM: xterm
       # no need to record these runs yet
-      CYPRESS_RECORD_KEY: ''
+      CYPRESS_RECORD_KEY: ""
       # while debugging https://github.com/cypress-io/cypress/issues/6053
       DEBUG: cypress:server:protocol
     steps:
@@ -147,7 +147,7 @@ jobs:
     environment:
       TERM: xterm
       # no need to record these runs yet
-      CYPRESS_RECORD_KEY: ''
+      CYPRESS_RECORD_KEY: ""
       # while debugging https://github.com/cypress-io/cypress/issues/6053
       DEBUG: cypress:server:protocol
     steps:
@@ -163,7 +163,7 @@ jobs:
     environment:
       TERM: xterm
       # no need to record these runs yet
-      CYPRESS_RECORD_KEY: ''
+      CYPRESS_RECORD_KEY: ""
     steps:
       - attach_workspace:
           at: ~/
@@ -253,7 +253,7 @@ jobs:
     # in this particular example we want to grep tests
     # and run only tests with name having "@admin"
     environment:
-      CYPRESS_grep: '@admin'
+      CYPRESS_grep: "@admin"
   preprocessors__flow-browserify:
     <<: *defaults
   preprocessors__typescript-browserify:
@@ -365,6 +365,7 @@ all_jobs: &all_jobs
         branches:
           only:
             - master
+            - fix-record-workflow
             # for https://github.com/cypress-io/cypress-example-recipes/issues/531
             - record-test-examples-job
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ defaults: &defaults
     test-command:
       description: Custom test command to use to run tests, like "npm run test:ci"
       type: string
-      default: ""
+      default: ''
   parallelism: 1
   working_directory: ~/app
   docker:
@@ -124,7 +124,7 @@ jobs:
     environment:
       TERM: xterm
       # no need to record these runs yet
-      CYPRESS_RECORD_KEY: ""
+      CYPRESS_RECORD_KEY: ''
       # while debugging https://github.com/cypress-io/cypress/issues/6053
       DEBUG: cypress:server:protocol
     steps:
@@ -147,7 +147,7 @@ jobs:
     environment:
       TERM: xterm
       # no need to record these runs yet
-      CYPRESS_RECORD_KEY: ""
+      CYPRESS_RECORD_KEY: ''
       # while debugging https://github.com/cypress-io/cypress/issues/6053
       DEBUG: cypress:server:protocol
     steps:
@@ -163,7 +163,7 @@ jobs:
     environment:
       TERM: xterm
       # no need to record these runs yet
-      CYPRESS_RECORD_KEY: ""
+      CYPRESS_RECORD_KEY: ''
     steps:
       - attach_workspace:
           at: ~/
@@ -253,7 +253,7 @@ jobs:
     # in this particular example we want to grep tests
     # and run only tests with name having "@admin"
     environment:
-      CYPRESS_grep: "@admin"
+      CYPRESS_grep: '@admin'
   preprocessors__flow-browserify:
     <<: *defaults
   preprocessors__typescript-browserify:
@@ -365,7 +365,6 @@ all_jobs: &all_jobs
         branches:
           only:
             - master
-            - fix-record-workflow
             # for https://github.com/cypress-io/cypress-example-recipes/issues/531
             - record-test-examples-job
 

--- a/examples/fundamentals__module-api/e2e-tests.js
+++ b/examples/fundamentals__module-api/e2e-tests.js
@@ -7,6 +7,7 @@ const cypress = require('cypress')
 const globby = require('globby')
 const Promise = require('bluebird')
 const fs = require('fs')
+const minimist = require('minimist')
 
 require('console.table')
 
@@ -26,11 +27,14 @@ const sortByLastModified = (filenames) => {
   return withTimes.sort(byTime)
 }
 
+const args = minimist(process.argv)
+
 const runOneSpec = (spec) => {
   return cypress.run({
     config: {
       video: false,
     },
+    record: args.record,
     spec: spec.filename,
   })
 }

--- a/examples/fundamentals__module-api/package.json
+++ b/examples/fundamentals__module-api/package.json
@@ -7,6 +7,6 @@
     "cypress:run": "node ./e2e-tests",
     "start": "echo nothing to start",
     "test:ci": "node ./e2e-tests",
-    "test:ci:record": "node ./e2e-tests"
+    "test:ci:record": "node ./e2e-tests --record"
   }
 }

--- a/examples/stubbing-spying__functions/package.json
+++ b/examples/stubbing-spying__functions/package.json
@@ -7,6 +7,6 @@
     "cypress:run": "../../node_modules/.bin/cypress run",
     "start": "echo nothing to start, this recipe does not run server",
     "test:ci": "npm run cypress:run",
-    "test:ci:record": "npm run cypress:run --record"
+    "test:ci:record": "npm run cypress:run -- --record"
   }
 }

--- a/examples/stubbing-spying__google-analytics/package.json
+++ b/examples/stubbing-spying__google-analytics/package.json
@@ -7,6 +7,6 @@
     "cypress:run": "../../node_modules/.bin/cypress run",
     "start": "echo",
     "test:ci": "npm run cypress:run",
-    "test:ci:record": "npm run cypress:run --record"
+    "test:ci:record": "npm run cypress:run -- --record"
   }
 }

--- a/examples/stubbing-spying__navigator/package.json
+++ b/examples/stubbing-spying__navigator/package.json
@@ -6,6 +6,6 @@
     "cypress:open": "../../node_modules/.bin/cypress open",
     "cypress:run": "../../node_modules/.bin/cypress run",
     "test:ci": "npm run cypress:run",
-    "test:ci:record": "npm run cypress:run --record"
+    "test:ci:record": "npm run cypress:run -- --record"
   }
 }


### PR DESCRIPTION
When we ran `npm run test:ci` in our `test-examples` job in CI, we weren't recording some of the runs to Cypress Cloud that we intended to record. This was causing issues. The job is passing now https://app.circleci.com/pipelines/github/cypress-io/cypress-example-recipes/3353/workflows/ecdf1d36-3006-4b7a-b9cf-63283acb6158/jobs/269132