### PR TITLE
Download recipe cy command

### DIFF
--- a/examples/testing-dom__download/README.md
+++ b/examples/testing-dom__download/README.md
@@ -16,6 +16,7 @@ Spec file | Description
 [local-download-spec.cy.js](./cypress/e2e/local-download-spec.cy.js) | Downloads files from local domain by using `<a href=... download>` anchor links
 [location-href-spec.cy.js](./cypress/e2e/location-href-spec.cy.js) | Intercepts and verifies a file downloaded via setting `document.location.href=...` URL
 [remote-download-spec.cy.js](./cypress/e2e/remote-download-spec.cy.js) | Downloads files from another domain by using `<a href=... download>` anchor links
+[download-click-command.js](./cypress/e2e/download-click-command.js) | Add a cypress helper to allow you to avoid "waiting for page load"
 
 ## Notes
 

--- a/examples/testing-dom__download/cypress/e2e/download-click-command.js
+++ b/examples/testing-dom__download/cypress/e2e/download-click-command.js
@@ -1,0 +1,22 @@
+// add this to your cypress commands.js file:
+
+/**
+ * When we download a file with a button click, Cypress expects a page reload. This causes our tests to fail even when the
+ * file is downloaded successfully. This helper fudges a page reload so that Cypress doesn't fail the test.
+ */
+Cypress.Commands.add('downloadClick', (callBack, timeout = 5000) => {
+	cy.window().then((win) => {
+		win.document.addEventListener('click', () => {
+			setTimeout(() => {
+				win.document.location.reload();
+			}, timeout);
+		});
+		
+		callBack();
+	});
+})
+
+// and then in your test you can use it like so:
+cy.downloadClick(() => {
+	cy.get('.your-download-button').click()
+}, 3000) // passing in the timeout is optional


### PR DESCRIPTION
This PR adds a cypress command example recipe for a helper to avoid the issue where tests fail for waiting for a page load that will never happen