### PR TITLE
chore: Remove nightly jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,15 +733,3 @@ workflows:
   # run this workflow on each commit and pull request
   all-recipes:
     jobs: *all_jobs
-
-  # since this is testing a lot of external sites
-  # let's run these tests once per day (at night)
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs: *all_jobs


### PR DESCRIPTION
We have a nightly job that is running that no one inspects. We should remove this and save the resources. 