### PR TITLE
Remove Blog link 'run in Docker' - outdated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Recipe | Description
 [Visual Testing](https://on.cypress.io/visual-testing) | Official Cypress guide to visual testing
 [Code Coverage](https://on.cypress.io/code-coverage) | Official Cypress guide to code coverage
 [detect-page-reload](https://glebbahmutov.com/blog/detect-page-reload/) | How to detect from Cypress test when a page reloads using object property assertions
-[run in Docker](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/) | Run Cypress with a single Docker command
 [SSR E2E](https://glebbahmutov.com/blog/ssr-e2e/) | End-to-end Testing for Server-Side Rendered Pages
 [Using TS aliases](https://glebbahmutov.com/blog/using-ts-aliases-in-cypress-tests/) | Using TypeScript aliases in Cypress tests
 [stub-navigator-api](https://glebbahmutov.com/blog/stub-navigator-api/) | Stub navigator API in end-to-end tests


### PR DESCRIPTION
## Issue

[README > Other Cypress Recipes](https://github.com/cypress-io/cypress-example-recipes/blob/master/README.md#other-cypress-recipes) contains a link to the outdated Blog article

| Recipe                                                                                            | Description                              |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [run in Docker](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/) | Run Cypress with a single Docker command |

### Article

The [blog article](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/) dated May 2, 2019 is based on legacy Cypress version `3.x` and Cypress Docker images released before the Cypress Factory process was introduced in January 2023. Node.js `12.x` used in the examples reached end-of-life in April 2022. The repo [bahmutov/demo-docker-cypress-included](https://github.com/bahmutov/demo-docker-cypress-included) was last updated in January 2021.

- The linked example repo [bahmutov/demo-docker-cypress-included](https://github.com/bahmutov/demo-docker-cypress-included) no longer works (see below).

- Video recording is no longer on by default.

- The linked example repo [cypress-io/cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose) is archived and therefore is no longer supported and maintained.

- The linked example repo [bahmutov/cypress-open-from-docker-compose](https://github.com/bahmutov/cypress-open-from-docker-compose) still works, however it is based on the legacy Cypress `4.0.2` version.

- The `docker-compose` specification of `version` is now obsolete.

### demo-docker-cypress-included

The repo [bahmutov/demo-docker-cypress-included](https://github.com/bahmutov/demo-docker-cypress-included) was last updated in January 2021.

- The test website http://todomvc.com/examples/vue/ is no longer functioning and the Cypress tests fail.
- The instructions to run `./cy-run.sh` do not work. Dependencies need to be installed.
- The `package-lock.json` uses lockfile `v1` which causes a warning on Node.js `18.x` (the lowest currently supported version of Node.js).
- The examples use inconsistent legacy versions of `cypress/included` images.
- The script `cy-open.sh` does not work correctly on Ubuntu.

### cypress-example-docker-compose

The repo [cypress-io/cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose) was archived in February 2024. It uses the `cypress/base:16` image, which is now unsupported due to Node.js `16.x` end-of-life. The demo does however still work and it uses Cypress `13.6.4`.

### cypress-open-from-docker-compose

The repo [bahmutov/cypress-open-from-docker-compose](https://github.com/bahmutov/cypress-open-from-docker-compose) was last updated in March 2020.

It uses the legacy `cypress/included:4.0.2` image.

## Change

Remove the reference in [README > Other Cypress Recipes](https://github.com/cypress-io/cypress-example-recipes/blob/master/README.md#other-cypress-recipes) to Blog article:

| Recipe                                                                                            | Description                              |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [run in Docker](https://www.cypress.io/blog/2019/05/02/run-cypress-with-a-single-docker-command/) | Run Cypress with a single Docker command |

There are too many legacy, outdated, non-working, unsupported example and demo references in this blog article.

The repo https://github.com/cypress-io/cypress-docker-images contains up-to-date information on using Cypress Docker images and it is currently better able to provide working instructions using non-legacy versions of Cypress.
