### PR TITLE
fix test-recipes script where error is throwing on www.cpyress.io 

### DIFF
--- a/examples/server-communication__visit-2nd-domain/cypress/e2e/using-file-spec.cy.js
+++ b/examples/server-communication__visit-2nd-domain/cypress/e2e/using-file-spec.cy.js
@@ -5,7 +5,9 @@ describe('Two domains using file', () => {
   Cypress.on('uncaught:exception', (err) => {
     // cypress.io has a few React exceptions related to state hydration,
     // but these exceptions do not impact this test
-    if (err.message.includes('Minified React error')) {
+    // This is also true with Cannot read properties of null (reading 'addEventListener') which has to due with the osano library
+    // that is on www.cypress.io
+    if (err.message.includes('Minified React error') || err.message.includes(`Cannot read properties of null (reading 'addEventListener')`)) {
       return false
     }
 

--- a/examples/server-communication__visit-2nd-domain/cypress/e2e/using-task-spec.cy.js
+++ b/examples/server-communication__visit-2nd-domain/cypress/e2e/using-task-spec.cy.js
@@ -3,7 +3,9 @@ describe('Two domains', () => {
   Cypress.on('uncaught:exception', (err) => {
     // cypress.io has a few React exceptions related to state hydration,
     // but these exceptions do not impact this test
-    if (err.message.includes('Minified React error')) {
+    // This is also true with Cannot read properties of null (reading 'addEventListener') which has to due with the osano library
+    // that is on www.cypress.io
+    if (err.message.includes('Minified React error') || err.message.includes(`Cannot read properties of null (reading 'addEventListener')`)) {
       return false
     }
 

--- a/examples/testing-dom__page-source/cypress/e2e/spec.cy.js
+++ b/examples/testing-dom__page-source/cypress/e2e/spec.cy.js
@@ -4,7 +4,9 @@ describe('Page source', () => {
   Cypress.on('uncaught:exception', (err) => {
     // cypress.io has a few React exceptions related to state hydration,
     // but these exceptions do not impact this test
-    if (err.message.includes('Minified React error')) {
+    // This is also true with Cannot read properties of null (reading 'addEventListener') which has to due with the osano library
+    // that is on www.cypress.io
+    if (err.message.includes('Minified React error') || err.message.includes(`Cannot read properties of null (reading 'addEventListener')`)) {
       return false
     }
 

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "x2js": "3.4.1"
   },
   "engines": {
-    "node": "^18.16.0"
+    "node": "^18.16.0 || ^20.11.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Currently the test-recipes-binary in the cypress app is failing due to this error when loading `www.cypress.io`. This error can be ignored for the test. also updates the engine for whats in the `.node-version`

#### before
<img width="1718" alt="Screenshot 2024-07-25 at 1 35 19 PM" src="https://github.com/user-attachments/assets/cf624113-1422-47f0-a465-6849d6cef0e6">


#### after
<img width="1724" alt="Screenshot 2024-07-25 at 1 35 58 PM" src="https://github.com/user-attachments/assets/52719be2-03b7-4065-98a0-337d739ced92">
