### PR TITLE
fix: update ag-grid to use latest version as 27.3.0 is no longer hosted

### DIFF
--- a/examples/testing-dom__lit-element/cypress.config.js
+++ b/examples/testing-dom__lit-element/cypress.config.js
@@ -2,7 +2,6 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   fixturesFolder: false,
-  experimentalShadowDomSupport: true,
   e2e: {
     supportFile: false,
   },

--- a/examples/testing-dom__lit-element/elements.js
+++ b/examples/testing-dom__lit-element/elements.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'https://unpkg.com/lit-element@3.3.3/lit-element.js?module'
+import { LitElement, html } from 'https://unpkg.com/lit-element@4.1.1/lit-element.js?module'
 
 window.customElements.define('element-one', class extends LitElement {
   static get properties () {

--- a/examples/testing-dom__sorting-table/cypress/e2e/spec.cy.js
+++ b/examples/testing-dom__sorting-table/cypress/e2e/spec.cy.js
@@ -18,7 +18,7 @@ describe('Sorting table', () => {
       cy.contains('.ag-header-cell-label', 'Price').click()
       // check ↑ is visible
       cy.contains('.ag-header-cell-label', 'Price')
-      .find('[ref=eSortAsc]').should('be.visible')
+      .find('[data-ref=eSortAsc]').should('be.visible')
 
       // verify the prices in the column are indeed in sorted order
       const cellsToPriceObjects = (cells$) => {

--- a/examples/testing-dom__sorting-table/index.html
+++ b/examples/testing-dom__sorting-table/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Ag-Grid Basic Example</title>
-  <script src="https://unpkg.com/ag-grid-community@27.3.0/dist/ag-grid-community.min.js"></script>
+  <script src="https://unpkg.com/ag-grid-community@33.2.1/dist/ag-grid-community.min.js"></script>
   <script src="main.js"></script>
 </head>
 

--- a/examples/testing-dom__sorting-table/main.js
+++ b/examples/testing-dom__sorting-table/main.js
@@ -23,5 +23,5 @@ const gridOptions = {
 document.addEventListener('DOMContentLoaded', function () {
   const gridDiv = document.querySelector('#myGrid')
 
-  new agGrid.Grid(gridDiv, gridOptions)
+  agGrid.createGrid(gridDiv, gridOptions)
 })


### PR DESCRIPTION
this test is currently failing in CI, due to ag-grid missing. This has to do with `https://unpkg.com/ag-grid-community@27.3.0/dist/ag-grid-community.min.js` no longer be available, so we are updating to `33.2.1` to keep the example working