### PR TITLE
fix: subdomains recipe failing for electron-36

### DIFF
--- a/examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js
+++ b/examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js
@@ -23,6 +23,8 @@ describe('Subdomains', () => {
 
       expect(selector, `logo selector for ${url}`).to.be.a('string')
 
+      cy.get('[aria-label="Cookie Consent Banner"] button').click()
+
       cy.get(selector).should('be.visible')
     })
   })


### PR DESCRIPTION
This may be flake rather than electron-36 related, it just cropped up more often with that upgrade.

This ensures the "cookie consent banner," which often renders on top of the Cypress logo, is dismissed before asserting on the visibility of the Cypress logo.