### PR TITLE
fix: update recipes to use cy.task

### DIFF
--- a/examples/logging-in__jwt/cypress.config.js
+++ b/examples/logging-in__jwt/cypress.config.js
@@ -4,10 +4,20 @@ module.exports = defineConfig({
   fixturesFolder: false,
   env: {
     username: 'test',
-    password: 'test',
   },
   e2e: {
     baseUrl: 'http://localhost:8081',
     supportFile: false,
+    setupNodeEvents (on, config) {
+      on('task', {
+        getUserPassword () {
+          return {
+            password: 'test',
+          }
+        },
+      })
+
+      return config
+    },
   },
 })

--- a/examples/logging-in__jwt/cypress/e2e/spec.cy.js
+++ b/examples/logging-in__jwt/cypress/e2e/spec.cy.js
@@ -4,13 +4,15 @@
 let user
 
 before(function fetchUser () {
-  cy.request('POST', 'http://localhost:4000/users/authenticate', {
-    username: Cypress.env('username'),
-    password: Cypress.env('password'),
-  })
-  .its('body')
-  .then((res) => {
-    user = res
+  cy.task('getUserPassword').then(({ password }) => {
+    cy.request('POST', 'http://localhost:4000/users/authenticate', {
+      username: Cypress.env('username'),
+      password,
+    })
+    .its('body')
+    .then((res) => {
+      user = res
+    })
   })
 })
 

--- a/examples/logging-in__jwt/cypress/e2e/using-ui-spec.cy.js
+++ b/examples/logging-in__jwt/cypress/e2e/using-ui-spec.cy.js
@@ -6,7 +6,10 @@ describe('logs in', () => {
 
     // enter valid username and password
     cy.get('[name=username]').type(Cypress.env('username'))
-    cy.get('[name=password]').type(Cypress.env('password'))
+    cy.task('getUserPassword').then(({ password }) => {
+      cy.get('[name=password]').type(password)
+    })
+
     cy.contains('button', 'Login').click()
 
     // confirm we have logged in successfully


### PR DESCRIPTION
Updates example recipes to avoid storing passwords in `Cypress.env()` as they could be available in the browser context