### PR TITLE
test: dismiss subdomains cookie banner only when visible

### DIFF
--- a/examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js
+++ b/examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js
@@ -23,7 +23,16 @@ describe('Subdomains', () => {
 
       expect(selector, `logo selector for ${url}`).to.be.a('string')
 
-      cy.get('[aria-label="Cookie Consent Banner"] button').click()
+      // The Osano cookie banner is third-party and may not appear (or may
+      // be in a hidden state if consent is already persisted). Dismiss it
+      // only when it is actually visible.
+      cy.get('body').then(($body) => {
+        const $banner = $body.find('[aria-label="Cookie Consent Banner"] button')
+
+        if ($banner.length && $banner.is(':visible')) {
+          cy.wrap($banner).first().click()
+        }
+      })
 
       cy.get(selector).should('be.visible')
     })


### PR DESCRIPTION
## Summary

The `Subdomains` recipe in `fundamentals__dynamic-tests` flakes intermittently on `https://docs.cypress.io` with:

```
CypressError: Timed out retrying after 4050ms: cy.click() failed because this element is not visible:
<button class=" osano-cm-dialog__close osano-cm-close ">...</button>
This element is not visible because its parent
<div ... osano-cm-dialog osano-cm-dialog--hidden ...> has CSS property: visibility: hidden
```

Example failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/81994/workflows/68bcd008-3b4c-4548-a1f0-18dd2e89fee2/jobs/3657590

The Osano cookie banner is third-party. The button element is present in the DOM immediately (so `cy.get` resolves), but its container can stay in the `osano-cm-dialog--hidden` state (`visibility: hidden`) — for example when consent has already been persisted, or when the loader is slow to animate the dialog in. The unconditional click added in #924 then fails the actionability check and the test bails.

This change makes the dismissal best-effort: we look up the button synchronously and click only when it's actually visible. The subsequent logo assertion still validates the real behavior the recipe is demonstrating.

## Changes

- `examples/fundamentals__dynamic-tests/cypress/e2e/subdomains-spec.cy.js`: guard the cookie-banner click with a visibility check.

## Test plan

- [x] CI passes on the recipes suite
- [x] `subdomains-spec.cy.js` passes against both `https://docs.cypress.io` and `https://www.cypress.io` whether or not the Osano banner is visible