### PR TITLE
fix: find app iframe by selector in chrome-remote-debugging hover task

### DIFF
--- a/examples/fundamentals__chrome-remote-debugging/cypress.config.js
+++ b/examples/fundamentals__chrome-remote-debugging/cypress.config.js
@@ -73,22 +73,34 @@ module.exports = defineConfig({
           await client.DOM.enable()
           await client.CSS.enable()
 
-          // as the Window consists of two IFrames, we must retrieve the right one
+          // The window contains multiple same-origin iframes (e.g. the reporter
+          // frame and the app frame), so find the one that actually holds the
+          // element rather than assuming a fixed position.
           const allRootNodes = await client.DOM.getFlattenedDocument()
 
           const isIframe = (node) => {
             return node.nodeName === 'IFRAME' && node.contentDocument
           }
 
-          const filtered = allRootNodes.nodes.filter(isIframe)
+          const frames = allRootNodes.nodes.filter(isIframe)
 
-          // The first IFrame is our App
-          const root = filtered[0].contentDocument
+          let nodeId
 
-          const { nodeId } = await client.DOM.querySelector({
-            nodeId: root.nodeId,
-            selector,
-          })
+          for (const frame of frames) {
+            const { nodeId: found } = await client.DOM.querySelector({
+              nodeId: frame.contentDocument.nodeId,
+              selector,
+            })
+
+            if (found) {
+              nodeId = found
+              break
+            }
+          }
+
+          if (!nodeId) {
+            throw new Error(`Could not find an iframe containing selector: ${selector}`)
+          }
 
           return client.CSS.forcePseudoState({
             nodeId,


### PR DESCRIPTION
## Problem

In `examples/fundamentals__chrome-remote-debugging`, the `activateHoverPseudo` CDP task assumed the application-under-test was the **first** iframe in the flattened document:

```js
const filtered = allRootNodes.nodes.filter(isIframe)
// The first IFrame is our App
const root = filtered[0].contentDocument
```

Cypress [PR #34242](https://github.com/cypress-io/cypress/pull/34242) (reporter-in-iframe) renders the Cypress reporter/command-log into its own same-origin `#reporter-frame` iframe, which sorts **before** the AUT iframe (`#unified-runner`) in document order. That makes `filtered[0]` the reporter frame, so `DOM.querySelector` finds nothing, `nodeId` is `undefined`, and `CSS.forcePseudoState` throws `Error: Could not find node with given id`.

This currently fails the `test-binary-against-recipes-chrome` CI job on that Cypress PR (spec `spec.cy.js`, test "Hover pseudo element is active").

## Fix

Search each same-origin iframe for the target selector rather than assuming a fixed position. This is robust to the reporter iframe, the app iframe, and any nesting/ordering.

## Verification

Ran the recipe locally against Cypress 15.17.0 — all 6 tests pass, including "Hover pseudo element is active":

```
✓ Printable div is not visible normally
✓ Printable div is visible with 'print' media query
✓ Hover pseudo element is inactive normally
✓ Hover pseudo element is active
✓ check visibility of div
✓ div should be visible again before print media query is activated
6 passing
```

The change is backward-compatible with the current released runner (single AUT iframe) and forward-compatible with the reporter-in-iframe layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)